### PR TITLE
Update how to escape special characters

### DIFF
--- a/src/mrkdwn/escape.ts
+++ b/src/mrkdwn/escape.ts
@@ -1,35 +1,21 @@
 // An internal HTML tag and emoji shorthand should not escape
 const preventEscapeRegex = /(<.*?>|:[-a-z0-9ÀÁÂÃÄÇÈÉÊËÍÎÏÑÓÔÕÖŒœÙÚÛÜŸßàáâãäçèéêëíîïñóôõöùúûüÿ_＿+＋'\u2e80-\u2fd5\u3005\u3041-\u3096\u30a0-\u30ff\u3400-\u4db5\u4e00-\u9fcb\uff10-\uff19\uff41-\uff5a\uff61-\uff9f]+:)/
 
-const generateReplacerForEscape = (fallback: string) => (matched: string) =>
-  `<span data-escape="${fallback.repeat(matched.length)}">${matched}</span>`
+const escapedChar = (char: string) => `\u034f${char}`
 
 export const escapeReplacers = {
-  blockquote: (partial: string) =>
-    partial
-      .replace(
-        /^((?:<.*?>)*)(&gt;)/gm,
-        (_, leading, character) => `${leading}\u00ad${character}`
-      )
-      .replace(
-        /^((?:<.*?>)*)(＞)/gm,
-        (_, leading, character) =>
-          `${leading}${generateReplacerForEscape('\u00ad＞')(character)}`
-      ),
-  bold: (partial: string) =>
-    partial
-      .replace(/\*+/g, generateReplacerForEscape('\u2217'))
-      .replace(/＊+/g, generateReplacerForEscape('\ufe61')),
-  italic: (partial: string) =>
-    partial
-      .replace(/_+/g, generateReplacerForEscape('\u02cd'))
-      .replace(/＿+/g, generateReplacerForEscape('\u2e0f')),
-  code: (partial: string) =>
-    partial
-      .replace(/`+/g, generateReplacerForEscape('\u02cb'))
-      .replace(/｀+/g, generateReplacerForEscape('\u02cb')),
-  strikethrough: (partial: string) =>
-    partial.replace(/~+/g, generateReplacerForEscape('\u223c')),
+  blockquote: (str: string) =>
+    str.replace(
+      /^((?:<.*?>)*)(&gt;|＞)/gm,
+      (_, leading, char) => `${leading}${escapedChar(char)}`
+    ),
+  bold: (str: string) =>
+    str.replace(/\*/g, escapedChar('*')).replace(/＊/g, '\u273b'),
+  italic: (str: string) =>
+    str.replace(/_/g, escapedChar('_')).replace(/＿/g, escapedChar('＿')),
+  code: (str: string) =>
+    str.replace(/`/g, escapedChar('`')).replace(/｀/g, escapedChar('｀')),
+  strikethrough: (str: string) => str.replace(/~/g, escapedChar('~')),
 } as const
 
 const escapeCharsDefaultReplacer = (partial: string) =>

--- a/src/mrkdwn/index.ts
+++ b/src/mrkdwn/index.ts
@@ -68,15 +68,7 @@ const htmlToMrkdwn = (html: string) =>
 
           return elm
         },
-        span: (h, node) => {
-          if (node.properties['data-escape']) {
-            return {
-              ...toTextNode(h, node),
-              data: { escape: node.properties['data-escape'] },
-            }
-          }
-          return all(h, node)
-        },
+        span: all,
       },
     })
   )

--- a/src/mrkdwn/stringifier.ts
+++ b/src/mrkdwn/stringifier.ts
@@ -34,15 +34,6 @@ export class MrkdwnCompiler {
     root: (node) => this.renderCodeBlock(this.block(node)),
     text: (node) => {
       if (node.data?.time) return this.visitors.time(node)
-      if (node.data?.escape) {
-        let n = node
-
-        while ((n = n.parent))
-          if (n.type === 'link') return this.escape(node.data.escape)
-
-        return `<!date^00000000^{_}|${node.value}>`
-      }
-
       return this.escape(node.value)
     },
     paragraph: (node) => this.block(node),


### PR DESCRIPTION
Use CGJ (`\u034f`) to escape characters, for getting unified rendering in several Slack clients including for Android. Resolves #187.

### Known issue

This change makes failure of styling in some edge cases:

```jsx
<Blocks>
  <Section><b>*Hello!</b></Section>
</Blocks>
```

|Current (date fallback)|Updated way|
|:---:|:---:|
|![](https://user-images.githubusercontent.com/3993388/89998414-7a33b380-dcc8-11ea-8f19-ff556dbf42d6.png)|![](https://user-images.githubusercontent.com/3993388/89998427-80299480-dcc8-11ea-8d96-6e53f938d8c8.png)|

In this case, we may need replacement of characters to similar  glyph like previous way