### PR TITLE
Remove deprecated jsxslack.raw

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@
 - Allow containing `<Input>` and input components in `<Blocks>` ([#218](https://github.com/yhatt/jsx-slack/issues/218), [#220](https://github.com/yhatt/jsx-slack/pull/220))
 - Upgrade dependent packages to the latest version ([#219](https://github.com/yhatt/jsx-slack/pull/219))
 
+### Removed
+
+- Remove deprecated `jsxslack.raw` ([#221](https://github.com/yhatt/jsx-slack/pull/221))
+
 ## v3.0.0 - 2021-02-25
 
 ### Breaking

--- a/src/tag.ts
+++ b/src/tag.ts
@@ -3,17 +3,10 @@ import htm from 'htm/mini'
 import * as blockKitComponents from './components'
 import { createElementInternal } from './jsx'
 
-interface JSXSlackTemplateTag {
-  (template: TemplateStringsArray, ...substitutions: any[]): any
-
-  /**
-   * An alias into `jsxslack` template literal tag.
-   *
-   * @deprecated `jsxslack.raw` has been deprecated and will remove in future
-   * version so you should use `jsxslack` instead.
-   */
-  readonly raw: JSXSlackTemplateTag
-}
+type JSXSlackTemplateTag = (
+  template: TemplateStringsArray,
+  ...substitutions: any[]
+) => any
 
 const strSubSymbol = Symbol('jsx-slack-subsitution')
 
@@ -72,7 +65,7 @@ const render = htm.bind((type, props, ...children) =>
  * if there are 2 and more elements.
  *
  * ```javascript
- * const Header = ({ children }) => jsxslack`
+ * const Heading = ({ children }) => jsxslack`
  *  <Section>
  *    <b>${children}</b>
  *  </Section>
@@ -85,7 +78,7 @@ const render = htm.bind((type, props, ...children) =>
  * ```javascript
  * jsxslack`
  *  <Blocks>
- *    <${Header}>
+ *    <${Heading}>
  *      <i>jsx-slack custom block</i> :sunglasses:
  *    <//>
  *    <Section>Let's build your block.</Section>
@@ -96,7 +89,7 @@ const render = htm.bind((type, props, ...children) =>
  * Please notice to a usage of component that has a bit different syntax from
  * JSX. {@link https://github.com/developit/htm Learn about HTM syntax}.
  */
-export const jsxslack = ((template, ...substitutions) =>
+export const jsxslack: JSXSlackTemplateTag = (template, ...substitutions) =>
   render(
     template,
     ...substitutions.map((s) =>
@@ -104,14 +97,4 @@ export const jsxslack = ((template, ...substitutions) =>
         ? Object.defineProperty(new String(s), strSubSymbol, { value: true })
         : s
     )
-  )) as JSXSlackTemplateTag
-
-// Deprecated jsxslack.raw
-Object.defineProperty(jsxslack, 'raw', {
-  value: (...params: Parameters<JSXSlackTemplateTag>) => {
-    console.warn(
-      '[DEPRECATION WARNING] `jsxslack.raw` is now just an alias into `jsxslack`. It has been deprecated and will remove in future version so you should use `jsxslack` instead.'
-    )
-    return jsxslack(...params)
-  },
-})
+  )

--- a/test/tag.tsx
+++ b/test/tag.tsx
@@ -161,14 +161,4 @@ describe('Tagged template', () => {
 
     expect(templateRawEntitySection).toStrictEqual(jsxRawEntitySection)
   })
-
-  describe('[DEPRECATED] jsxslack.raw', () => {
-    it('redirects to invoke into jsxslack', () => {
-      const text = 'hello'
-      const raw = jsxslack.raw`<Section>${text}<//>`
-
-      expect(raw).toStrictEqual(<Section>{text}</Section>)
-      expect(raw).toStrictEqual(jsxslack`<Section>${text}<//>`)
-    })
-  })
 })


### PR DESCRIPTION
`jsxslack.raw` has already marked as deprecated in jsx-slack v2.