### PR TITLE
Add type exports that are similar to `@types/react`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added type exports that are similar to `@types/react` ([#226](https://github.com/yhatt/jsx-slack/pull/226))
+  - `FunctionCompnent` / `FC` (Alias to same types in `JSXSlack` namespace)
+  - `VoidFunctionComponent` / `VFC` (Alias to same types in `JSXSlack` namespace)
+  - `Node` (Similar to `ReactNode` but for jsx-slack. Alias to `JSXSlack.ChildElements`)
+
 ### Changed
 
 - Upgrade dependent packages to the latest version ([#225](https://github.com/yhatt/jsx-slack/pull/225))

--- a/package.json
+++ b/package.json
@@ -112,6 +112,7 @@
     "he": "^1.2.0"
   },
   "resolutions": {
+    "css-what": "^5.0.1",
     "cssnano": "^5.0.5"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/ban-types */
 import { JSXSlack } from './jsx'
 
 export { JSXSlack }
@@ -5,9 +6,10 @@ export * from './components'
 export { jsxslack } from './tag'
 export default JSXSlack
 
-// Useful types similar to @types/react
+// Useful type aliases that are similar to @types/react
 export type Node = JSXSlack.ChildElements
-export type FunctionComponent = JSXSlack.FunctionComponent
-export type FC = JSXSlack.FC
-export type VoidFunctionComponent = JSXSlack.VoidFunctionComponent
-export type VFC = JSXSlack.VFC
+export type FunctionComponent<P extends {} = {}> = JSXSlack.FunctionComponent<P>
+export type FC<P extends {} = {}> = JSXSlack.FC<P>
+export type VoidFunctionComponent<P extends {} = Record<any, never>> =
+  JSXSlack.VoidFunctionComponent<P>
+export type VFC<P extends {} = Record<any, never>> = JSXSlack.VFC<P>

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,3 +4,10 @@ export { JSXSlack }
 export * from './components'
 export { jsxslack } from './tag'
 export default JSXSlack
+
+// Useful types similar to @types/react
+export type Node = JSXSlack.ChildElements
+export type FunctionComponent = JSXSlack.FunctionComponent
+export type FC = JSXSlack.FC
+export type VoidFunctionComponent = JSXSlack.VoidFunctionComponent
+export type VFC = JSXSlack.VFC

--- a/src/jsx.ts
+++ b/src/jsx.ts
@@ -201,7 +201,17 @@ export namespace JSXSlack {
     props: Props<P>
   ) => Node | null
 
+  export type FunctionComponent<P extends {} = {}> = FunctionalComponent<P>
   export type FC<P extends {} = {}> = FunctionalComponent<P>
+
+  export type VoidFunctionalComponent<P extends {} = Record<any, never>> = (
+    props: P
+  ) => Node | null
+
+  export type VoidFunctionComponent<P extends {} = Record<any, never>> =
+    VoidFunctionalComponent<P>
+  export type VFC<P extends {} = Record<any, never>> =
+    VoidFunctionalComponent<P>
 
   export interface Node<P extends {} = any> {
     readonly $$jsxslack: {

--- a/test/jsx.tsx
+++ b/test/jsx.tsx
@@ -1,4 +1,10 @@
 /** @jsx JSXSlack.h */
+import type {
+  FC,
+  FunctionComponent,
+  VFC,
+  VoidFunctionComponent,
+} from '../src/index'
 import {
   JSXSlack,
   createComponent,
@@ -257,21 +263,29 @@ describe('JSX', () => {
   })
 
   describe('Types', () => {
-    describe('JSXSlack.FunctionalComponent / JSXSlack.FunctionComponent / JSXSlack.FC', () => {
+    describe('JSXSlack.FunctionalComponent / (JSXSlack.)FunctionComponent / (JSXSlack.)FC', () => {
       it('accepts specified props and children', () => {
         const functionalComponent: JSXSlack.FunctionalComponent = () => null
         const functionComponent: JSXSlack.FunctionComponent = () => null
         const fc: JSXSlack.FC<{ test: string }> = ({ test }) => (
           <JSXSlack.Fragment>{test}</JSXSlack.Fragment>
         )
+        const publicFunctionComponent: FunctionComponent<{ test: string }> = ({
+          test,
+        }) => <JSXSlack.Fragment>{test}</JSXSlack.Fragment>
+        const publicFC: FC<{}> = () => null // eslint-disable-line @typescript-eslint/ban-types
 
         expect(functionalComponent({ children: [] })).toBeNull()
         expect(functionComponent({ children: [] })).toBeNull()
         expect(fc({ test: 'abc', children: [] })).toStrictEqual(['abc'])
+        expect(
+          publicFunctionComponent({ test: 'def', children: [] })
+        ).toStrictEqual(['def'])
+        expect(publicFC({ children: [] })).toBeNull()
       })
     })
 
-    describe('JSXSlack.VoidFunctionalComponent / JSXSlack.VoidFunctionComponent / JSXSlack.VFC', () => {
+    describe('JSXSlack.VoidFunctionalComponent / (JSXSlack.)VoidFunctionComponent / (JSXSlack.)VFC', () => {
       it('accepts only specified props', () => {
         const voidFunctionalComponent: JSXSlack.VoidFunctionalComponent = () =>
           null
@@ -279,6 +293,10 @@ describe('JSX', () => {
         const vfc: JSXSlack.VFC<{ test: string }> = ({ test }) => (
           <JSXSlack.Fragment>{test}</JSXSlack.Fragment>
         )
+        const publicVoidFunctionComponent: VoidFunctionComponent<{
+          test: string
+        }> = ({ test }) => <JSXSlack.Fragment>{test}</JSXSlack.Fragment>
+        const publicVFC: VFC<Record<string, never>> = () => null
 
         // @ts-expect-error children prop is not allowed in VoidFunctionalComponent
         expect(voidFunctionalComponent({ children: [] })).toBeNull()
@@ -291,6 +309,18 @@ describe('JSX', () => {
         // @ts-expect-error children prop is not allowed in VoidFunctionalComponent
         expect(vfc({ test: 'abc', children: [] })).toStrictEqual(['abc'])
         expect(vfc({ test: 'def' })).toStrictEqual(['def'])
+
+        expect(
+          // @ts-expect-error children prop is not allowed in VoidFunctionalComponent
+          publicVoidFunctionComponent({ test: 'abc', children: [] })
+        ).toStrictEqual(['abc'])
+        expect(publicVoidFunctionComponent({ test: 'def' })).toStrictEqual([
+          'def',
+        ])
+
+        // @ts-expect-error children prop is not allowed in VoidFunctionalComponent
+        expect(publicVFC({ children: [] })).toBeNull()
+        expect(publicVFC({})).toBeNull()
       })
     })
   })

--- a/test/jsx.tsx
+++ b/test/jsx.tsx
@@ -6,7 +6,7 @@ import {
   isValidElementFromComponent,
 } from '../src/jsx'
 
-describe('JSXSlack v2', () => {
+describe('JSX', () => {
   describe('JSXSlack()', () => {
     it('has noop', () => {
       const Component = createComponent('test', () => ({ foo: 'bar' }))
@@ -252,6 +252,45 @@ describe('JSXSlack v2', () => {
             </JSXSlack.Fragment>
           )
         ).toHaveLength(14)
+      })
+    })
+  })
+
+  describe('Types', () => {
+    describe('JSXSlack.FunctionalComponent / JSXSlack.FunctionComponent / JSXSlack.FC', () => {
+      it('accepts specified props and children', () => {
+        const functionalComponent: JSXSlack.FunctionalComponent = () => null
+        const functionComponent: JSXSlack.FunctionComponent = () => null
+        const fc: JSXSlack.FC<{ test: string }> = ({ test }) => (
+          <JSXSlack.Fragment>{test}</JSXSlack.Fragment>
+        )
+
+        expect(functionalComponent({ children: [] })).toBeNull()
+        expect(functionComponent({ children: [] })).toBeNull()
+        expect(fc({ test: 'abc', children: [] })).toStrictEqual(['abc'])
+      })
+    })
+
+    describe('JSXSlack.VoidFunctionalComponent / JSXSlack.VoidFunctionComponent / JSXSlack.VFC', () => {
+      it('accepts only specified props', () => {
+        const voidFunctionalComponent: JSXSlack.VoidFunctionalComponent = () =>
+          null
+        const voidFunctionComponent: JSXSlack.VoidFunctionComponent = () => null
+        const vfc: JSXSlack.VFC<{ test: string }> = ({ test }) => (
+          <JSXSlack.Fragment>{test}</JSXSlack.Fragment>
+        )
+
+        // @ts-expect-error children prop is not allowed in VoidFunctionalComponent
+        expect(voidFunctionalComponent({ children: [] })).toBeNull()
+        expect(voidFunctionalComponent({})).toBeNull()
+
+        // @ts-expect-error children prop is not allowed in VoidFunctionalComponent
+        expect(voidFunctionComponent({ children: [] })).toBeNull()
+        expect(voidFunctionComponent({})).toBeNull()
+
+        // @ts-expect-error children prop is not allowed in VoidFunctionalComponent
+        expect(vfc({ test: 'abc', children: [] })).toStrictEqual(['abc'])
+        expect(vfc({ test: 'def' })).toStrictEqual(['def'])
       })
     })
   })

--- a/yarn.lock
+++ b/yarn.lock
@@ -2163,10 +2163,10 @@ css-tree@^1.1.2:
     mdn-data "2.0.14"
     source-map "^0.6.1"
 
-css-what@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/css-what/-/css-what-4.0.0.tgz#35e73761cab2eeb3d3661126b23d7aa0e8432233"
-  integrity sha512-teijzG7kwYfNVsUh2H/YN62xW3KK9YhXEgSlbxMlcyjPNvdKJqFx5lrwlJgoFP1ZHlB89iGDlo/JyshKeRhv5A==
+css-what@^4.0.0, css-what@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/css-what/-/css-what-5.0.1.tgz#3efa820131f4669a8ac2408f9c32e7c7de9f4cad"
+  integrity sha512-FYDTSHb/7KXsWICVsxdmiExPjCfRC4qRFBdVwv7Ax9hMnvMmEjP9RfxTEZ3qPZGmADDn2vAKSo9UcN1jKVYscg==
 
 cssesc@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
Some types have already provided by `JSXSlack`, but the relation between the name and role is different against React so they may confuse React users.

I added `FunctionComponent` / `FC`, `VoidFunctionComponent` / `VFC`, and `Node` (≒ `ReactNode`) types. These are public types that are exported from `jsx-slack` directly and can use as like to `@types/react`.

### Added types

- `FunctionComponent` / `FC` / `JSXSlack.FunctionComponent`: Alias to `JSXSlack.FunctionalComponent` (`JSXSlack.FC`).
- `VoidFunctionComponent` / `VFC` / `JSXSlack.VoidFunctionalComponent` / `JSXSlack.VoidFunctionComponent` / `JSXSlack.VFC`: New type to create function component without implicit `children` prop.
  - To follow breaking change in coming React 18,  also `FC` may remove implicit children prop in the next major version.
- `Node`: Alias to `JSXSlack.ChildElements`. It is same as `React.ReactNode` in terms of allowing all JSX types that jsx-slack accepts