### PR TITLE
Support `submit_disabled: true` by setting `<Modal type="workflow_step" submit={false}>`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,17 +4,13 @@
 
 ### Added
 
-- Support assigning [`submit_disabled` field](https://api.slack.com/reference/workflows/configuration-view) by setting `submit` prop as `false` in `<Modal type="workflow_step">` ([#234](https://github.com/yhatt/jsx-slack/pull/234))
+- Support assigning [`submit_disabled` field](https://api.slack.com/reference/workflows/configuration-view) by setting `submit` prop as `false` in `<Modal type="workflow_step">` ([#233](https://github.com/yhatt/jsx-slack/issues/233), [#234](https://github.com/yhatt/jsx-slack/pull/234))
 
 ## v4.2.1 - 2021-06-18
 
-### Added
-
-- JSX runtime scripts with ES modules ([#232](https://github.com/yhatt/jsx-slack/pull/232))
-
 ### Fixed
 
-- Fixed script resolution error when using JSX runtime script through ES modules ([#231](https://github.com/yhatt/jsx-slack/issues/231))
+- Fixed resolution error when using JSX runtime script through ES modules ([#231](https://github.com/yhatt/jsx-slack/issues/231), [#232](https://github.com/yhatt/jsx-slack/pull/232))
 
 ## v4.2.0 - 2021-06-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Support assigning [`submit_disabled` field](https://api.slack.com/reference/workflows/configuration-view) by setting `submit` prop as `false` in `<Modal type="workflow_step">` ([#234](https://github.com/yhatt/jsx-slack/pull/234))
+
 ## v4.2.1 - 2021-06-18
 
 ### Added

--- a/docs/block-containers.md
+++ b/docs/block-containers.md
@@ -70,7 +70,7 @@ export const shareModal = (opts) => (
 
 - `type` (optional): Set a type of modal.
   - [`modal`](https://api.slack.com/reference/surfaces/views) _(default)_: The regular modal surface.
-  - [`workflow_step`](https://api.slack.com/reference/workflows/configuration-view): The modal surface for [custom workflow step](https://api.slack.com/workflows/steps). In this type, some props for around of the content are ignored.
+  - [`workflow_step`](https://api.slack.com/reference/workflows/configuration-view): The modal surface for [custom workflow step](https://api.slack.com/workflows/steps).
 
 * `privateMetadata` (optional): An optional string that can be found in payloads of some interactive events Slack app received (3000 characters maximum). [By setting function, you can use the custom transformer to serialize hidden values set up via `<Input type="hidden">`](block-elements.md#custom-transformer).
 * `callbackId` (optional): An identifier for this modal to recognize it in various events. (255 characters maximum)
@@ -85,6 +85,10 @@ export const shareModal = (opts) => (
 - `externalId` (optional): A unique ID for all views on a per-team basis.
 
 > :information_source: Slack requires the submit text when modal has component for inputs, so jsx-slack would set the text "Submit" as the default value of `submit` prop if you are setting no submit text in any way together with using input components.
+
+#### Props for `workflow_step` type
+
+- `submit` (optional): By setting as `false`, the submit button will be disabled _until one or more inputs have filled_. It is corresponding with [`submit_disabled` field in a configuration view object](https://api.slack.com/reference/workflows/configuration-view).
 
 ## <a name="home" id="home"></a> [`<Home>`: The view container for home tabs](https://api.slack.com/surfaces/tabs)
 

--- a/src/block-kit/container/Modal.tsx
+++ b/src/block-kit/container/Modal.tsx
@@ -115,7 +115,7 @@ interface WorkflowStepModalProps extends ModalPropsBase {
    * By setting `submit` as `false`, the submit button will be disabled _until
    * one or more inputs have filled_.
    */
-  submit?: false
+  submit?: boolean
 }
 
 type ModalProps = DistributedProps<BasicModalProps | WorkflowStepModalProps>

--- a/src/block-kit/container/Modal.tsx
+++ b/src/block-kit/container/Modal.tsx
@@ -83,11 +83,11 @@ interface BasicModalProps extends ModalPropsBase {
   notifyOnClose?: boolean
 
   /**
-   * A text for submit button of the modal. (24 characters maximum)
+   * A text for submit button of the regular modal. (24 characters maximum)
    *
-   * If not defined this prop and the modal required the submit button, the
-   * label will be defined by `<input type="submit">` in children, or used
-   * default label "Submit".
+   * If not defined this prop in the regular modal and it required the submit
+   * button, the label will be defined by `<input type="submit">` in children,
+   * or used default label "Submit".
    */
   submit?: string
 
@@ -98,7 +98,7 @@ interface BasicModalProps extends ModalPropsBase {
    * Set a type of modal.
    *
    * - `modal` (default): The regular modal surface.
-   * - `workflow_step`: The modal surface for {@link https://api.slack.com/workflows/steps|custom workflow step}.
+   * - `workflow_step`: The modal surface for [custom workflow step](https://api.slack.com/workflows/steps).
    * In this type, some props for around of the content are ignored.
    */
   type?: 'modal'
@@ -106,6 +106,17 @@ interface BasicModalProps extends ModalPropsBase {
 
 interface WorkflowStepModalProps extends ModalPropsBase {
   type: 'workflow_step'
+
+  /**
+   * ### `workflow_step` type
+   *
+   * When type prop has set as workflow_step, this prop has a different meaning
+   * corresponded with [`submit_disabled` field in Slack API](https://api.slack.com/reference/workflows/configuration-view).
+   *
+   * By setting `submit` as `false`, the submit button will be disabled _until
+   * one or more inputs have filled_.
+   */
+  submit?: false
 }
 
 type ModalProps = DistributedProps<BasicModalProps | WorkflowStepModalProps>
@@ -236,12 +247,16 @@ export const Modal = createComponent<ModalProps, View>('Modal', (props) => {
       props.notifyOnClose !== undefined ? !!props.notifyOnClose : undefined,
   }
 
+  const workflowStepModalPayloads: Partial<View> = {
+    submit_disabled: props.submit !== undefined ? !props.submit : undefined,
+  }
+
   return {
     type,
     callback_id: props.callbackId,
     external_id: props.externalId,
     private_metadata: privateMetadata,
-    ...(type === 'modal' ? basicModalPayloads : {}),
+    ...(type === 'modal' ? basicModalPayloads : workflowStepModalPayloads),
     blocks: cleanMeta(<ModalBlocks children={children} />) as any[],
   }
 })

--- a/src/block-kit/container/Modal.tsx
+++ b/src/block-kit/container/Modal.tsx
@@ -99,7 +99,6 @@ interface BasicModalProps extends ModalPropsBase {
    *
    * - `modal` (default): The regular modal surface.
    * - `workflow_step`: The modal surface for [custom workflow step](https://api.slack.com/workflows/steps).
-   * In this type, some props for around of the content are ignored.
    */
   type?: 'modal'
 }
@@ -111,7 +110,7 @@ interface WorkflowStepModalProps extends ModalPropsBase {
    * ### `workflow_step` type
    *
    * When type prop has set as workflow_step, this prop has a different meaning
-   * corresponded with [`submit_disabled` field in Slack API](https://api.slack.com/reference/workflows/configuration-view).
+   * corresponded with [`submit_disabled` field in a configuration view object](https://api.slack.com/reference/workflows/configuration-view).
    *
    * By setting `submit` as `false`, the submit button will be disabled _until
    * one or more inputs have filled_.

--- a/test/block-kit/container-components.tsx
+++ b/test/block-kit/container-components.tsx
@@ -300,9 +300,8 @@ describe('Container components', () => {
           })
         })
 
-        it('assigns submit_disabled field as false if defined truthy value (wrong way)', () => {
+        it('assigns submit_disabled field as false if defined truthy value', () => {
           expect(
-            // @ts-expect-error
             <Modal type="workflow_step" submit>
               {}
             </Modal>

--- a/test/block-kit/container-components.tsx
+++ b/test/block-kit/container-components.tsx
@@ -248,16 +248,19 @@ describe('Container components', () => {
       ).not.toStrictEqual(expect.objectContaining({ submit }))
     })
 
-    describe('with `workflow_step` type', () => {
+    describe('`workflow_step` type', () => {
       it('ignores some props about for around of the modal content', () => {
-        expect(
+        const workflowStep = (
           <Modal type="workflow_step">
             <Input type="submit" value="submit" />
           </Modal>
-        ).toStrictEqual({
+        )
+
+        expect(workflowStep).toStrictEqual({
           type: 'workflow_step',
           blocks: [],
         })
+        expect(workflowStep).not.toHaveProperty('submit_disabled')
 
         const workflowStepFull = (
           // @ts-expect-error
@@ -282,6 +285,42 @@ describe('Container components', () => {
         expect(workflowStepFull).not.toHaveProperty('close')
         expect(workflowStepFull).not.toHaveProperty('clear_on_close')
         expect(workflowStepFull).not.toHaveProperty('notify_on_close')
+      })
+
+      describe('submit prop', () => {
+        it('assigns submit_disabled field as true if defined submit as false', () => {
+          expect(
+            <Modal type="workflow_step" submit={false}>
+              {}
+            </Modal>
+          ).toStrictEqual({
+            type: 'workflow_step',
+            submit_disabled: true,
+            blocks: [],
+          })
+        })
+
+        it('assigns submit_disabled field as false if defined truthy value (wrong way)', () => {
+          expect(
+            // @ts-expect-error
+            <Modal type="workflow_step" submit>
+              {}
+            </Modal>
+          ).toStrictEqual({
+            type: 'workflow_step',
+            submit_disabled: false,
+            blocks: [],
+          })
+        })
+
+        it('does not assign submit_disabled field to the regular modal even if defined as false', () => {
+          expect(
+            // @ts-expect-error
+            <Modal type="modal" submit={false}>
+              {}
+            </Modal>
+          ).not.toHaveProperty('submit_disabled')
+        })
       })
     })
   })


### PR DESCRIPTION
Close #233.