### PR TITLE
Update links in JSDoc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Support assigning [`submit_disabled` field](https://api.slack.com/reference/workflows/configuration-view) by setting `submit` prop as `false` in `<Modal type="workflow_step">` ([#233](https://github.com/yhatt/jsx-slack/issues/233), [#234](https://github.com/yhatt/jsx-slack/pull/234))
 
+### Fixed
+
+- Broken JSDoc links in some IDEs ([#235](https://github.com/yhatt/jsx-slack/pull/235))
+
 ## v4.2.1 - 2021-06-18
 
 ### Fixed

--- a/src/block-kit/composition/Confirm.ts
+++ b/src/block-kit/composition/Confirm.ts
@@ -41,7 +41,7 @@ export interface ConfirmProps {
 export interface ConfirmableProps {
   /**
    * `<Confirm>` element or the raw
-   * {@link https://api.slack.com/reference/block-kit/composition-objects#confirm confirmation dialog composition object},
+   * [confirmation dialog composition object](https://api.slack.com/reference/block-kit/composition-objects#confirm),
    * for providing a confirmation step to interactive components.
    *
    * @example

--- a/src/block-kit/composition/Mrkdwn.tsx
+++ b/src/block-kit/composition/Mrkdwn.tsx
@@ -17,12 +17,12 @@ interface MrkdwnProps {
    * A boolean value whether to bypass HTML-like formatting by jsx-slack.
    *
    * If enabled, you can bypass HTML-like formatting, and disable auto escape for
-   * {@link https://api.slack.com/reference/surfaces/formatting#escaping mrkdwn special chracters}.
+   * [mrkdwn special chracters](https://api.slack.com/reference/surfaces/formatting#escaping).
    * The defined string in the content will be set as the `text` field of text
    * composition object as is. Any JSX tags cannot use in contents.
    *
    * It's useful for rendering a raw string that is including
-   * {@link https://api.slack.com/reference/surfaces/formatting#advanced advanced mrkdwn format for Slack}.
+   * [advanced mrkdwn format for Slack](https://api.slack.com/reference/surfaces/formatting#advanced).
    *
    * ```jsx
    * <Blocks>
@@ -44,7 +44,7 @@ interface MrkdwnProps {
    * **We recommend always use `<Mrkdwn verbatim>` in your app.**
    *
    * Slack is pointing out it has some possibilities for breaking messages.
-   * _Read "{@link https://api.slack.com/reference/surfaces/formatting#why_you_should_consider_disabling_automatic_parsing Why you should consider disabling automatic parsing}"
+   * _Read "[Why you should consider disabling automatic parsing](https://api.slack.com/reference/surfaces/formatting#why_you_should_consider_disabling_automatic_parsing)"
    * in the documentation by Slack._
    */
   verbatim?: boolean
@@ -53,7 +53,7 @@ interface MrkdwnProps {
 const defaultProps = { verbatim: true }
 
 /**
- * Generate {@link https://api.slack.com/reference/block-kit/composition-objects#textthe the text composition object}
+ * Generate [the text composition object](https://api.slack.com/reference/block-kit/composition-objects#textthe)
  * for `mrkdwn` type.
  *
  * You should contain the content of the message formatted by HTML-like elements
@@ -70,7 +70,7 @@ const defaultProps = { verbatim: true }
  *
  * HTML-like formatting by jsx-slack is a comfortable way to define Slack Block
  * Kit surfaces with familiar syntaxes, but auto-escape for
- * {@link https://api.slack.com/reference/surfaces/formatting#escaping mrkdwn special chracters}
+ * [mrkdwn special chracters](https://api.slack.com/reference/surfaces/formatting#escaping)
  * may interfere with the completed mrkdwn text.
  *
  * You can use `<Mrkdwn raw>` if you want to use the raw mrkdwn string as is. It
@@ -88,7 +88,7 @@ const defaultProps = { verbatim: true }
  *
  * ---
  *
- * ### Automatic parsing _({@link https://api.slack.com/reference/surfaces/formatting#why_you_should_consider_disabling_automatic_parsing not recommended})_
+ * ### Automatic parsing _([not recommended](https://api.slack.com/reference/surfaces/formatting#why_you_should_consider_disabling_automatic_parsing))_
  *
  * jsx-slack has disabled automatic parsing of URL, mention, and channel link by
  * Slack to prevent breaking explicitly specified formatting. By using
@@ -142,7 +142,7 @@ const defaultProps = { verbatim: true }
  * probably you always must use `<Mrkdwn verbatim>`.
  *
  * Slack is pointing out it has some possibilities for breaking messages. _Read
- * "{@link https://api.slack.com/reference/surfaces/formatting#why_you_should_consider_disabling_automatic_parsing Why you should consider disabling automatic parsing}"
+ * "[Why you should consider disabling automatic parsing](https://api.slack.com/reference/surfaces/formatting#why_you_should_consider_disabling_automatic_parsing)"
  * in the documentation by Slack._
  *
  * @returns The JSON of the composition object for mrkdwn text

--- a/src/block-kit/composition/utils.ts
+++ b/src/block-kit/composition/utils.ts
@@ -39,8 +39,8 @@ export interface FilterProps {
 
   /**
    * A boolean value whether to exclude external
-   * {@link https://api.slack.com/enterprise/shared-channels shared channels}
-   * from conversations list.
+   * [shared channels](https://api.slack.com/apis/channels-between-orgs) from
+   * conversations list.
    */
   excludeExternalSharedChannels?: boolean
 
@@ -58,7 +58,7 @@ export interface InputDispatchActionProps {
    * If defined interaction type(s) as space-separated string or array, you can
    * determine when the plain-text input component will return the payload, as
    * same as
-   * {@link https://api.slack.com/reference/block-kit/composition-objects#dispatch_action_config defining `dispatch_action_config` in Slack API}.
+   * [defining `dispatch_action_config` in Slack API](https://api.slack.com/reference/block-kit/composition-objects#dispatch_action_config).
    *
    * - `onEnterPressed`: Payload is dispatched when hitting Enter key while
    *   focusing to the input component.

--- a/src/block-kit/container/Blocks.ts
+++ b/src/block-kit/container/Blocks.ts
@@ -14,7 +14,7 @@ import {
 
 /**
  * The basic container component for Slack Block Kit suited to
- * {@link https://api.slack.com/surfaces/messages|messages}.
+ * [messages](https://api.slack.com/surfaces/messages).
  *
  * `<Blocks>` can include following block elements:
  *
@@ -58,7 +58,7 @@ import {
  * with `JSXSlack(<Blocks>...</Blocks>)`.
  *
  * @return An array of block elements, for `blocks` field in
- *  {@link https://api.slack.com/methods/chat.postMessage|chat.postMessage} API.
+ *   [`chat.postMessage`](https://api.slack.com/methods/chat.postMessage) API.
  */
 export const Blocks = generateBlocksContainer({
   name: 'Blocks',

--- a/src/block-kit/container/Home.tsx
+++ b/src/block-kit/container/Home.tsx
@@ -89,7 +89,7 @@ const HomeBlocks = generateBlocksContainer({
 
 /**
  * The container component for the view of
- * {@link https://api.slack.com/surfaces/tabs|home tabs}.
+ * [home tabs](https://api.slack.com/surfaces/tabs).
  *
  * `<Home>` can include following block elements:
  *
@@ -131,7 +131,7 @@ const HomeBlocks = generateBlocksContainer({
  * with `JSXSlack(<Home>...</Home>)`.
  *
  * @return The object of `view` payload, for `view` field in
- *   {@link https://api.slack.com/methods/views.publish|views.publish} API.
+ *   [`views.publish`](https://api.slack.com/methods/views.publish) API.
  */
 export const Home = createComponent<HomeProps, View>('Home', (props) => {
   let pmObject: Record<string, any> | undefined

--- a/src/block-kit/container/Modal.tsx
+++ b/src/block-kit/container/Modal.tsx
@@ -147,7 +147,7 @@ const commonDefaultSubmit = plainText('Submit')
 
 /**
  * The container component for the view of
- * {@link https://api.slack.com/surfaces/modals|modals}.
+ * [modals](https://api.slack.com/surfaces/modals).
  *
  * `<Modal>` can include following block elements:
  *
@@ -189,7 +189,7 @@ const commonDefaultSubmit = plainText('Submit')
  * with `JSXSlack(<Modal>...</Modal>)`.
  *
  * @return The object of `view` payload, for `view` field in
- *   {@link https://api.slack.com/methods/views.open|views.open} and some
+ *   [`views.open`](https://api.slack.com/methods/views.open) and some
  *   similar APIs
  */
 export const Modal = createComponent<ModalProps, View>('Modal', (props) => {

--- a/src/block-kit/elements/Button.ts
+++ b/src/block-kit/elements/Button.ts
@@ -34,7 +34,7 @@ export interface ButtonProps extends ActionProps, ConfirmableProps {
 
 /**
  * The interactive component for
- * {@link https://api.slack.com/reference/block-kit/block-elements#button the `button` block element}.
+ * [the `button` block element](https://api.slack.com/reference/block-kit/block-elements#button).
  *
  * You should set the plain-text label for the button in its children.
  *

--- a/src/block-kit/elements/ChannelsSelect.ts
+++ b/src/block-kit/elements/ChannelsSelect.ts
@@ -52,8 +52,8 @@ export type ChannelsSelectProps = DistributedProps<
 
 /**
  * The interactive component or input component for
- * {@link https://api.slack.com/reference/block-kit/block-elements#channel_select the `channels_select` block element} and
- * {@link https://api.slack.com/reference/block-kit/block-elements#channel_multi_select the `multi_channels_select` block element}.
+ * [the `channels_select` block element](https://api.slack.com/reference/block-kit/block-elements#channel_select) and
+ * [the `multi_channels_select` block element](https://api.slack.com/reference/block-kit/block-elements#channel_multi_select).
  *
  * Provide a selectable menu element from a list of _public_ channels visible to
  * the current user in the active workspace.

--- a/src/block-kit/elements/CheckboxGroup.ts
+++ b/src/block-kit/elements/CheckboxGroup.ts
@@ -34,7 +34,7 @@ type CheckboxGroupProps = InputComponentProps<CheckboxGroupBaseProps>
 
 /**
  * The interactive component or input component for
- * {@link https://api.slack.com/reference/block-kit/block-elements#checkboxes the `checkboxes` block element}.
+ * [the `checkboxes` block element](https://api.slack.com/reference/block-kit/block-elements#checkboxes).
  *
  * Provide the container to choose multiple options supplied by `<Checkbox>`.
  *

--- a/src/block-kit/elements/ConversationsSelect.ts
+++ b/src/block-kit/elements/ConversationsSelect.ts
@@ -67,8 +67,8 @@ export type ConversationsSelectProps = DistributedProps<
 
 /**
  * The interactive component or input component for
- * {@link https://api.slack.com/reference/block-kit/block-elements#conversation_select the `conversations_select` block element} and
- * {@link https://api.slack.com/reference/block-kit/block-elements#conversation_multi_select the `multi_conversations_select` block element}.
+ * [the `conversations_select` block element](https://api.slack.com/reference/block-kit/block-elements#conversation_select) and
+ * [the `multi_conversations_select` block element](https://api.slack.com/reference/block-kit/block-elements#conversation_multi_select).
  *
  * Provide a selectable menu element from a list of many kind of conversations
  * visible to the current user in the active workspace.

--- a/src/block-kit/elements/DatePicker.ts
+++ b/src/block-kit/elements/DatePicker.ts
@@ -27,7 +27,7 @@ export type DatePickerProps = InputComponentProps<DatePickerBaseProps>
 
 /**
  * The interactive component or input component for
- * {@link https://api.slack.com/reference/block-kit/block-elements#datepicker the `datepicker` block element}.
+ * [the `datepicker` block element](https://api.slack.com/reference/block-kit/block-elements#datepicker).
  *
  * It makes easy to select a date through the calendar interface.
  *

--- a/src/block-kit/elements/ExternalSelect.ts
+++ b/src/block-kit/elements/ExternalSelect.ts
@@ -28,7 +28,7 @@ interface SingleExternalSelectProps
    * An initial option _exactly_ matched to provided options from external
    * source.
    *
-   * It accepts the raw {@link https://api.slack.com/reference/block-kit/composition-objects#option option composition object}
+   * It accepts the raw [option composition object](https://api.slack.com/reference/block-kit/composition-objects#option)
    * or `<Option>` element.
    */
   initialOption?: OptionType
@@ -61,14 +61,14 @@ export type ExternalSelectProps = InputComponentProps<
 
 /**
  * The interactive component or input component for
- * {@link https://api.slack.com/reference/block-kit/block-elements#external_select the `external_select` block element} and
- * {@link https://api.slack.com/reference/block-kit/block-elements#external_multi_select the `multi_external_select` block element}.
+ * [the `external_select` block element](https://api.slack.com/reference/block-kit/block-elements#external_select) and
+ * [the `multi_external_select` block element](https://api.slack.com/reference/block-kit/block-elements#external_multi_select).
  *
  * Provide a selectable menu element from dynamic options supplied by the
  * external source.
  *
  * Slack app will need to set up the supplier of option elements first.
- * {@link https://api.slack.com/reference/block-kit/block-elements#external_select Learn about external source in Slack documentation.}
+ * [Learn about external source in Slack documentation.](https://api.slack.com/reference/block-kit/block-elements#external_select)
  * `<SelectFragment>` component would be useful to supply dynamic options
  * through JSX.
  *

--- a/src/block-kit/elements/Overflow.ts
+++ b/src/block-kit/elements/Overflow.ts
@@ -42,7 +42,7 @@ export const OverflowItem = createComponent<OverflowItemProps, Option>(
 
 /**
  * The interactive component for
- * {@link https://api.slack.com/reference/block-kit/block-elements#overflow the `overflow` block element}.
+ * [the `overflow` block element](https://api.slack.com/reference/block-kit/block-elements#overflow).
  *
  * It provides an overflow menu button displayed as "...". User can access to
  * some menu items defined by `<OverflowItem>` in children by click the button.

--- a/src/block-kit/elements/RadioButtonGroup.ts
+++ b/src/block-kit/elements/RadioButtonGroup.ts
@@ -34,7 +34,7 @@ type RadioButtonGroupProps = InputComponentProps<RadioButtonGroupBaseProps>
 
 /**
  * The interactive component or input component for
- * {@link https://api.slack.com/reference/block-kit/block-elements#radio the `radio_buttons` block element}.
+ * [the `radio_buttons` block element](https://api.slack.com/reference/block-kit/block-elements#radio).
  *
  * Provide the container to choose one of the options supplied by
  * `<RadioButton>`.

--- a/src/block-kit/elements/Select.tsx
+++ b/src/block-kit/elements/Select.tsx
@@ -55,8 +55,8 @@ export type SelectProps = InputComponentProps<
 
 /**
  * The interactive component or input component for
- * {@link https://api.slack.com/reference/block-kit/block-elements#static_select the `static_select` block element} and
- * {@link https://api.slack.com/reference/block-kit/block-elements#static_multi_select the `multi_static_select` block element}.
+ * [the `static_select` block element](https://api.slack.com/reference/block-kit/block-elements#static_select) and
+ * [the `multi_static_select` block element](https://api.slack.com/reference/block-kit/block-elements#static_multi_select).
  *
  * Provide a menu element with static options by the similar interface to
  * `<select>` HTML element. It must contain elements either of `<Option>` or

--- a/src/block-kit/elements/TimePicker.ts
+++ b/src/block-kit/elements/TimePicker.ts
@@ -35,7 +35,7 @@ export type TimePickerProps = InputComponentProps<TimePickerBaseProps>
 
 /**
  * The interactive component or input component for
- * {@link https://api.slack.com/reference/block-kit/block-elements#timepicker the `timepicker` block element}.
+ * [the `timepicker` block element](https://api.slack.com/reference/block-kit/block-elements#timepicker).
  *
  * It makes easy to select the specific time through a dropdown or a native
  * interface suited to the device.

--- a/src/block-kit/elements/UsersSelect.ts
+++ b/src/block-kit/elements/UsersSelect.ts
@@ -46,8 +46,8 @@ export type UsersSelectProps = InputComponentProps<
 
 /**
  * The interactive component or input component for
- * {@link https://api.slack.com/reference/block-kit/block-elements#users_select the `users_select` block element} and
- * {@link https://api.slack.com/reference/block-kit/block-elements#users_multi_select the `multi_users_select` block element}.
+ * [the `users_select` block element](https://api.slack.com/reference/block-kit/block-elements#users_select) and
+ * [the `multi_users_select` block element](https://api.slack.com/reference/block-kit/block-elements#users_multi_select).
  *
  * Provide a selectable menu element from a list of Slack users visible to the
  * current user in the active workspace.

--- a/src/block-kit/elements/utils.ts
+++ b/src/block-kit/elements/utils.ts
@@ -9,7 +9,7 @@ export interface ActionProps {
 export interface SingleSelectableProps {
   /**
    * A boolean value whether provide
-   * {@link https://api.slack.com/reference/block-kit/block-elements#multi_select the selectable menu from multiple options}.
+   * [the selectable menu from multiple options](https://api.slack.com/reference/block-kit/block-elements#multi_select).
    *
    * @remarks
    * *The multi-select menu cannot place in `<Actions>`.* jsx-slack throws an

--- a/src/block-kit/input/Textarea.tsx
+++ b/src/block-kit/input/Textarea.tsx
@@ -11,7 +11,7 @@ export interface TextareaProps extends Omit<InputTextProps, 'type'> {}
 
 /**
  * The input component for rendering `input` layout block containing
- * {@link https://api.slack.com/reference/block-kit/block-elements#input a plain-text input}
+ * [a plain-text input](https://api.slack.com/reference/block-kit/block-elements#input)
  * with multiline text.
  *
  * It should place on immidiate children of container component.

--- a/src/block-kit/layout/Actions.ts
+++ b/src/block-kit/layout/Actions.ts
@@ -66,7 +66,7 @@ const actionTypeValidators: Record<string, (action: Action) => void> = {
 }
 
 /**
- * {@link https://api.slack.com/reference/messaging/blocks#actions|The `actions` layout block}
+ * [The `actions` layout block](https://api.slack.com/reference/messaging/blocks#actions)
  * to hold interactive elements.
  *
  * `<Actions>` allows containing up to 25 interactive elements, but Slack

--- a/src/block-kit/layout/Call.ts
+++ b/src/block-kit/layout/Call.ts
@@ -19,7 +19,7 @@ export interface CallProps extends LayoutBlockProps {
  *
  * _This component is available only in `<Blocks>` container for messaging._
  *
- * Learn about {@link https://api.slack.com/apis/calls|using the Calls API} in
+ * Learn about [using the Calls API](https://api.slack.com/apis/calls) in
  * the document of Slack API.
  *
  * @return The partial JSON for `call` layout block

--- a/src/block-kit/layout/Context.ts
+++ b/src/block-kit/layout/Context.ts
@@ -12,7 +12,7 @@ interface ContextProps extends LayoutBlockProps {
 const endSymbol = Symbol('EndOfContext')
 
 /**
- * {@link https://api.slack.com/reference/messaging/blocks#context|The `context` layout block}
+ * [The `context` layout block](https://api.slack.com/reference/messaging/blocks#context)
  * to display the message context with small texts and icon images.
  *
  * `<Context>` allows containing mixed contents consisted of text messages

--- a/src/block-kit/layout/Divider.ts
+++ b/src/block-kit/layout/Divider.ts
@@ -7,7 +7,7 @@ export interface DividerProps extends LayoutBlockProps {
 }
 
 /**
- * {@link https://api.slack.com/reference/messaging/blocks#divider|The `divider` layout block}
+ * [The `divider` layout block](https://api.slack.com/reference/messaging/blocks#divider)
  * just to insert a divider.
  *
  * @return The partial JSON for `divider` layout block

--- a/src/block-kit/layout/File.ts
+++ b/src/block-kit/layout/File.ts
@@ -18,12 +18,12 @@ export interface FileProps extends LayoutBlockProps {
 }
 
 /**
- * {@link https://api.slack.com/reference/messaging/blocks#file|The `file` layout block}
+ * [The `file` layout block](https://api.slack.com/reference/messaging/blocks#file)
  * to display a remote file.
  *
  * _This component is available only in `<Blocks>` container for messaging._
  *
- * Learn about {@link https://api.slack.com/messaging/files/remote|adding remote files}
+ * Learn about [adding remote files](https://api.slack.com/messaging/files/remote)
  * in the document of Slack API.
  *
  * @return The partial JSON for `file` layout block

--- a/src/block-kit/layout/Header.ts
+++ b/src/block-kit/layout/Header.ts
@@ -8,7 +8,7 @@ export interface HeaderProps extends LayoutBlockProps {
 }
 
 /**
- * {@link https://api.slack.com/reference/messaging/blocks#header|The `header` layout block}
+ * [The `header` layout block](https://api.slack.com/reference/messaging/blocks#header)
  * to display plain text with bold font in a larger.
  *
  * ```jsx

--- a/src/block-kit/layout/Image.ts
+++ b/src/block-kit/layout/Image.ts
@@ -21,7 +21,7 @@ export interface ImageProps extends LayoutBlockProps {
 }
 
 /**
- * {@link https://api.slack.com/reference/messaging/blocks#image|The `image` layout block}
+ * [The `image` layout block](https://api.slack.com/reference/messaging/blocks#image)
  * to insert an image.
  *
  * It has well-known props like `<img>` HTML element.
@@ -35,7 +35,7 @@ export interface ImageProps extends LayoutBlockProps {
  * ---
  *
  * `<Image>` component also can use as
- * {@link https://api.slack.com/reference/block-kit/block-elements#image|the `image` block element},
+ * [the `image` block element](https://api.slack.com/reference/block-kit/block-elements#image),
  * for `<Section>` and `<Context>` layout block.
  *
  * ```jsx

--- a/src/block-kit/layout/Input.tsx
+++ b/src/block-kit/layout/Input.tsx
@@ -29,7 +29,7 @@ interface InputLayoutProps extends LayoutBlockProps {
 
   /**
    * By setting `true`, the input element will dispatch
-   * {@link https://api.slack.com/reference/interaction-payloads/block-actions `block_actions` payload}
+   * [`block_actions` payload](https://api.slack.com/reference/interaction-payloads/block-actions)
    * when used this.
    */
   dispatchAction?: boolean
@@ -62,7 +62,7 @@ interface InputComponentBaseProps extends Omit<InputLayoutProps, 'children'> {
 
   /**
    * By setting `true`, the input element will dispatch
-   * {@link https://api.slack.com/reference/interaction-payloads/block-actions `block_actions` payload}
+   * [`block_actions` payload](https://api.slack.com/reference/interaction-payloads/block-actions)
    * when used this.
    *
    * @remarks
@@ -138,7 +138,7 @@ export interface InputTextProps
    *
    * This prop would rather similar to `defaultValue` than `value` in React. A
    * defined value would be filled to the element only when the view was opened.
-   * {@link https://api.slack.com/methods/views.update `views.update`} cannot
+   * [`views.update`](https://api.slack.com/methods/views.update) cannot
    * update the text changed by user even if changed this prop.
    */
   value?: string
@@ -263,7 +263,7 @@ export const wrapInInput = <T extends object>(
 /**
  * `<Input>` has various usages: Input component for single text element,
  * helpers for the container, and Slack-style
- * {@link https://api.slack.com/reference/messaging/blocks#input|`input` layout block}.
+ * [`input` layout block](https://api.slack.com/reference/messaging/blocks#input).
  *
  * It should place on immidiate children of container component.
  *
@@ -330,7 +330,7 @@ export const wrapInInput = <T extends object>(
  * ### Slack-style `input` layout block
  *
  * `<Input>` also can render
- * {@link https://api.slack.com/reference/messaging/blocks#input|`input` layout block}
+ * [`input` layout block](https://api.slack.com/reference/messaging/blocks#input)
  * as same usage as other components for Slack layout block. Please place one of
  * the available interactive component as a child.
  *

--- a/src/block-kit/layout/Section.ts
+++ b/src/block-kit/layout/Section.ts
@@ -95,7 +95,7 @@ export const Field = createComponent<FieldProps, MrkdwnElement>(
 )
 
 /**
- * {@link https://api.slack.com/reference/messaging/blocks#section|The `section` layout block}
+ * [The `section` layout block](https://api.slack.com/reference/messaging/blocks#section)
  * to display text message, and optional fields / the accessory block element.
  *
  * You can style text contents through HTML-like formatting. For example, insert

--- a/src/block-kit/other/SelectFragment.ts
+++ b/src/block-kit/other/SelectFragment.ts
@@ -93,7 +93,7 @@ export const SelectFragmentInternal = createComponent<
  * children. The outputted JSON has an array of corresponded elements, or empty
  * options array if it has provided no options.
  *
- * For example, {@link https://slack.dev/bolt/concepts#options Bolt framework for JavaScript}
+ * For example, [Bolt framework for JavaScript](https://slack.dev/bolt/concepts#options)
  * by Slack can provide external data source easily by using `<SelectFragment>`
  * together.
  *

--- a/src/jsx.ts
+++ b/src/jsx.ts
@@ -482,7 +482,7 @@ export namespace JSXSlack {
        *
        * #### Link to public Slack channel
        *
-       * jsx-slack can create {@link https://api.slack.com/reference/surfaces/formatting#linking-channels a link to the Slack channel}
+       * jsx-slack can create [a link to the Slack channel](https://api.slack.com/reference/surfaces/formatting#linking-channels)
        * by specifying hash-prefixed ID for the public channel:
        * `<a href="#C0123456789" />` _(Notice that it is not the channel name)_
        *
@@ -499,7 +499,7 @@ export namespace JSXSlack {
        *
        * #### Special mentions
        *
-       * You can also use these {@link https://api.slack.com/reference/surfaces/formatting#special-mentions special mentions}
+       * You can also use these [special mentions](https://api.slack.com/reference/surfaces/formatting#special-mentions)
        * to send widely (but typically they should be used carefully):
        *
        * - `<a href="@here" />`
@@ -710,7 +710,7 @@ export namespace JSXSlack {
        *
        * It makes easy to render the formatted date and time with localized
        * timezone for each Slack user.
-       * {@link https://api.slack.com/reference/surfaces/formatting#date-formatting Learn about date formatting in Slack documentation.}
+       * [Learn about date formatting in Slack documentation.](https://api.slack.com/reference/surfaces/formatting#date-formatting)
        *
        * ```jsx
        * <time dateTime="1392734382">{'Posted {date_num} {time_secs}'}</time>

--- a/src/mrkdwn/jsx.ts
+++ b/src/mrkdwn/jsx.ts
@@ -123,7 +123,7 @@ const stringifyHtml = (
  * Preserve rendered special characters as plain text as possible.
  *
  * See our basic strategy to escape characters in
- * {@link https://github.com/yhatt/jsx-slack/blob/main/docs/about-escape-and-exact-mode.md#escape|the reference of jsx-slack}.
+ * [the reference of jsx-slack](https://github.com/yhatt/jsx-slack/blob/main/docs/about-escape-and-exact-mode.md#escape).
  *
  * It can use only in the context where HTML-like elements are available.
  *

--- a/src/tag.ts
+++ b/src/tag.ts
@@ -47,7 +47,7 @@ const render = htm.bind((type, props, ...children) =>
  * Template literal tag for rendering the JSX-compatible template into JSON.
  *
  * `jsxslack` allows using the template syntax almost the same as JSX, powered
- * by {@link https://github.com/developit/htm HTM (Hyperscript Tagged Markup) }.
+ * by [HTM (Hyperscript Tagged Markup)](https://github.com/developit/htm).
  * You can build Block Kit JSON without setting JSX transpiler and importing
  * built-in components.
  *
@@ -87,7 +87,7 @@ const render = htm.bind((type, props, ...children) =>
  * ```
  *
  * Please notice to a usage of component that has a bit different syntax from
- * JSX. {@link https://github.com/developit/htm Learn about HTM syntax}.
+ * JSX. [Learn about HTM syntax](https://github.com/developit/htm).
  */
 export const jsxslack: JSXSlackTemplateTag = (template, ...substitutions) =>
   render(


### PR DESCRIPTION
Some IDEs do no longer parse `@link` tag as hyperlink correctly. Many IDEs can parse Markdown-style link.