### PR TITLE
Avoid using namespace alias and use isomorphic namespace in JSX runtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Avoid using namespace alias and use isomorphic namespace in JSX runtime ([#249](https://github.com/yhatt/jsx-slack/pull/249))
+
 ## v4.4.0 - 2021-11-17
 
 ### Removed

--- a/src/jsx-runtime.ts
+++ b/src/jsx-runtime.ts
@@ -1,5 +1,5 @@
+/* eslint-disable @typescript-eslint/no-namespace, @typescript-eslint/no-empty-interface */
 import { JSXSlack, createElementInternal, FragmentInternal } from './jsx'
-import JSX = JSXSlack.JSX
 
 export const jsx = (type: any, props: Record<string, unknown>, key: any) =>
   createElementInternal(type ?? FragmentInternal, {
@@ -9,4 +9,9 @@ export const jsx = (type: any, props: Record<string, unknown>, key: any) =>
 
 export const jsxs = jsx
 
-export type { JSX }
+export namespace JSX {
+  export interface Element extends JSXSlack.JSX.Element {}
+  export interface IntrinsicElements extends JSXSlack.JSX.IntrinsicElements {}
+  export interface ElementChildrenAttribute
+    extends JSXSlack.JSX.ElementChildrenAttribute {}
+}


### PR DESCRIPTION
ESM ecosystem like skypack.dev may not parse [namespace alias syntax](https://www.typescriptlang.org/docs/handbook/namespaces.html#aliases) `import JSX = JSXSlack.JSX` in `.d.ts`.

For example, https://cdn.skypack.dev/-/jsx-slack@v4.4.0-ASn0IRbmAw9SeAGyKfkg/dist=es2019,mode=types/types/jsx-runtime.d.ts will return 500 internal server error but https://cdn.skypack.dev/-/jsx-slack@v4.4.0-ASn0IRbmAw9SeAGyKfkg/dist=es2019,mode=types/types/jsx.d.ts in the same directory will not.