### PR TITLE
Add internally named interface to props for generated `blocks` container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix internal type of `<Blocks>` for making better type support for ESM CDN ([#245](https://github.com/yhatt/jsx-slack/issues/245), [#250](https://github.com/yhatt/jsx-slack/pull/250))
+
 ## v4.4.1 - 2021-11-17
 
 ### Fixed

--- a/src/block-kit/container/utils.ts
+++ b/src/block-kit/container/utils.ts
@@ -16,52 +16,54 @@ export type PrivateMetadataTransformer = (
   hiddenValues: object | undefined
 ) => string | undefined
 
+export interface BlocksProps {
+  children: JSXSlack.ChildNodes
+}
+
 export const generateBlocksContainer = ({
   aliases,
   availableBlockTypes,
   typesToCheckMissingLabel,
   name,
 }: GenerateBlocksContainerOptions) =>
-  createComponent<{ children: JSXSlack.ChildNodes }, Block[]>(
-    name,
-    ({ children }) =>
-      JSXSlack.Children.toArray(children).reduce((reduced: Block[], child) => {
-        const tag = resolveTagName(child)
-        const target: typeof child | null =
-          JSXSlack.isValidElement(child) &&
-          typeof child.$$jsxslack.type === 'string' &&
-          aliases[child.$$jsxslack.type]
-            ? alias(child, aliases[child.$$jsxslack.type]) || child
-            : child
+  createComponent<BlocksProps, Block[]>(name, ({ children }) =>
+    JSXSlack.Children.toArray(children).reduce((reduced: Block[], child) => {
+      const tag = resolveTagName(child)
+      const target: typeof child | null =
+        JSXSlack.isValidElement(child) &&
+        typeof child.$$jsxslack.type === 'string' &&
+        aliases[child.$$jsxslack.type]
+          ? alias(child, aliases[child.$$jsxslack.type]) || child
+          : child
 
-        if (typeof target === 'object' && target) {
-          const block = target as Block
-          const validator = availableBlockTypes[block.type]
+      if (typeof target === 'object' && target) {
+        const block = target as Block
+        const validator = availableBlockTypes[block.type]
 
-          if (validator) {
-            if (typeof validator === 'function') validator(block)
-            return [...reduced, block]
-          }
-
-          let additional = ''
-
-          if (tag) {
-            additional = `Provided by ${tag}`
-
-            if ((typesToCheckMissingLabel || []).includes(block.type))
-              additional +=
-                '. Are you missing the definition of "label" prop to use the input component?'
-          }
-
-          throw new JSXSlackError(
-            `<${name}> has detected an invalid block type as the layout block: "${
-              block.type
-            }"${additional ? ` (${additional})` : ''}`,
-            child
-          )
+        if (validator) {
+          if (typeof validator === 'function') validator(block)
+          return [...reduced, block]
         }
-        return reduced
-      }, [])
+
+        let additional = ''
+
+        if (tag) {
+          additional = `Provided by ${tag}`
+
+          if ((typesToCheckMissingLabel || []).includes(block.type))
+            additional +=
+              '. Are you missing the definition of "label" prop to use the input component?'
+        }
+
+        throw new JSXSlackError(
+          `<${name}> has detected an invalid block type as the layout block: "${
+            block.type
+          }"${additional ? ` (${additional})` : ''}`,
+          child
+        )
+      }
+      return reduced
+    }, [])
   )
 
 export const generateActionsValidator =


### PR DESCRIPTION
Added internally named `BlocksProps` interface to `<Blocks>` container. It has been consistent with other block containers.

Previously Deno type check has broken by too omitted file name in the result of compile ☹️

![スクリーンショット 2021-11-18 4 52 39](https://user-images.githubusercontent.com/3993388/142273476-53c3f1eb-a925-4f40-91ba-c61171ba7e09.png)

An updated type should not generate weird import like that.

Related to #245.

