### PR TITLE
Add manual type assertion for `<Blocks>` to fix Deno's type error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix Deno's type error by adding manual type assertion for `<Blocks>` ([#245](https://github.com/yhatt/jsx-slack/issues/245), [#251](https://github.com/yhatt/jsx-slack/pull/251))
+
 ## v4.4.2 - 2021-11-17
 
 ### Fixed

--- a/src/block-kit/container/Blocks.ts
+++ b/src/block-kit/container/Blocks.ts
@@ -1,3 +1,4 @@
+import type { BuiltInComponent } from '../../jsx'
 import { Select } from '../elements/Select'
 import { Textarea } from '../input/Textarea'
 import { availableActionTypes } from '../layout/Actions'
@@ -7,6 +8,7 @@ import { Image } from '../layout/Image'
 import { Input, knownInputs } from '../layout/Input'
 import { availableSectionAccessoryTypes, Section } from '../layout/Section'
 import {
+  BlocksProps,
   generateActionsValidator,
   generateBlocksContainer,
   generateSectionValidator,
@@ -60,7 +62,7 @@ import {
  * @return An array of block elements, for `blocks` field in
  *   [`chat.postMessage`](https://api.slack.com/methods/chat.postMessage) API.
  */
-export const Blocks = generateBlocksContainer({
+export const Blocks: BuiltInComponent<BlocksProps> = generateBlocksContainer({
   name: 'Blocks',
   availableBlockTypes: {
     actions: generateActionsValidator([...availableActionTypes]),


### PR DESCRIPTION
Deno seems to throw a type error if there were multiple inline imports in one statement:

```
error: TS2694 [ERROR]: Namespace '__' has no exported member 'BlocksProps'.
export declare const Blocks: import("../../jsx.d.ts").BuiltInComponent<import("./utils.d.ts").BlocksProps>;
                                                                                              ~~~~~~~~~~~
    at https://cdn.esm.sh/v58/jsx-slack@4.4.2/types/block-kit/container/Blocks.d.ts:49:95
```

This PR adds manual type assertion for `<Blocks>` to fix this error. It has not any changes to the real type, but there are no inline `import()` syntaxes in the updated type definition so we can expect to be fixed type error in Deno.

Related: #245, #250