### PR TITLE
Fix TypeError while rendering lists and hyperlinks with JSX runtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix `TypeError` while rendering lists and hyperlinks with JSX runtime ([#258](https://github.com/yhatt/jsx-slack/issues/258), [#259](https://github.com/yhatt/jsx-slack/pull/259))
+
 ## v4.5.2 - 2021-12-18
 
 ### Added

--- a/jest.config.js
+++ b/jest.config.js
@@ -46,5 +46,6 @@ module.exports = {
   restoreMocks: true,
   testEnvironment: 'node',
   testMatch: ['<rootDir>/test/**/!(_)*.[jt]s?(x)'],
+  testPathIgnorePatterns: ['/node_modules/', 'babel.config.js'],
   transformIgnorePatterns: [`/node_modules/(?!${esModules.join('|')})`],
 }

--- a/src/mrkdwn/jsx.ts
+++ b/src/mrkdwn/jsx.ts
@@ -13,7 +13,12 @@ const buildAttr = (props: { [key: string]: any }, escapeEntities = true) => {
   let attr = ''
 
   for (const prop of Object.keys(props)) {
-    if (props[prop] !== undefined) {
+    if (
+      props[prop] != null &&
+      ['number', 'bigint', 'boolean', 'string', 'symbol'].includes(
+        typeof props[prop]
+      )
+    ) {
       let attrBase = props[prop].toString()
       if (escapeEntities) attrBase = escapeEntity(attrBase)
 

--- a/test/babel/automatic.jsx
+++ b/test/babel/automatic.jsx
@@ -1,6 +1,6 @@
 /** @jsxImportSource jsx-slack */
 import { JSXSlackError } from '../../src/error'
-import { Blocks, Fragment, Section, Select } from '../../src/index'
+import { Blocks, Fragment, Mrkdwn, Section, Select } from '../../src/index'
 
 jest.mock('../../jsx-dev-runtime')
 
@@ -13,17 +13,48 @@ describe('Babel transpilation through automatic runtime (Development mode)', () 
         </Section>
       </Blocks>
     ).toMatchInlineSnapshot(`
-    Array [
+          Array [
+            Object {
+              "text": Object {
+                "text": "Hello, world!",
+                "type": "mrkdwn",
+                "verbatim": true,
+              },
+              "type": "section",
+            },
+          ]
+      `)
+  })
+
+  it('accepts list items', () => {
+    expect(
+      <Mrkdwn>
+        <ul>
+          <li>item</li>
+        </ul>
+      </Mrkdwn>
+    ).toMatchInlineSnapshot(`
       Object {
-        "text": Object {
-          "text": "Hello, world!",
-          "type": "mrkdwn",
-          "verbatim": true,
-        },
-        "type": "section",
-      },
-    ]
-  `)
+        "text": "• item",
+        "type": "mrkdwn",
+      }
+    `)
+
+    // An edge case has reported to ordered list in https://github.com/yhatt/jsx-slack/issues/258)
+    expect(
+      <Mrkdwn>
+        <ol>
+          <li>item</li>
+          <li>item</li>
+        </ol>
+      </Mrkdwn>
+    ).toMatchInlineSnapshot(`
+      Object {
+        "text": "1. item
+      2. item",
+        "type": "mrkdwn",
+      }
+    `)
   })
 
   it('accepts fragment syntax', () => {
@@ -42,33 +73,33 @@ describe('Babel transpilation through automatic runtime (Development mode)', () 
         <Component />
       </Blocks>
     ).toMatchInlineSnapshot(`
-    Array [
-      Object {
-        "text": Object {
-          "text": "Section A",
-          "type": "mrkdwn",
-          "verbatim": true,
-        },
-        "type": "section",
-      },
-      Object {
-        "text": Object {
-          "text": "Section B",
-          "type": "mrkdwn",
-          "verbatim": true,
-        },
-        "type": "section",
-      },
-      Object {
-        "text": Object {
-          "text": "Section C",
-          "type": "mrkdwn",
-          "verbatim": true,
-        },
-        "type": "section",
-      },
-    ]
-  `)
+          Array [
+            Object {
+              "text": Object {
+                "text": "Section A",
+                "type": "mrkdwn",
+                "verbatim": true,
+              },
+              "type": "section",
+            },
+            Object {
+              "text": Object {
+                "text": "Section B",
+                "type": "mrkdwn",
+                "verbatim": true,
+              },
+              "type": "section",
+            },
+            Object {
+              "text": Object {
+                "text": "Section C",
+                "type": "mrkdwn",
+                "verbatim": true,
+              },
+              "type": "section",
+            },
+          ]
+      `)
 
     expect(fragment.$$jsxslack.type).toBe(Fragment)
   })

--- a/test/babel/babel.config.js
+++ b/test/babel/babel.config.js
@@ -1,0 +1,3 @@
+// This is workaround for https://github.com/facebook/jest/issues/12000.
+// Please remove if Jest was fixed to parse babel config placed to the root.
+module.exports = require('../../babel.config')


### PR DESCRIPTION
Fixed raising `TypeError` when using JSX runtime and `<ul>`, `<ol>`, and `<a>` have child HTML tag(s).

An internal `buildAttr` method for building the string of HTML attributes from JSX only accepts some primitive values now, and ignores such as `Object` and `Array`. It means an internal JSX parser will no longer try to coerce `children` prop to HTML attribute string.

Resolve #258.