### PR TITLE
Add JSX runtimes with mjs extension to fix esm.sh resolving error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Add JSX runtimes with mjs extension to fix esm.sh resolving error ([#260](https://github.com/yhatt/jsx-slack/pull/260))
+
 ## v4.5.3 - 2021-12-28
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Add JSX runtimes with mjs extension to fix esm.sh resolving error ([#260](https://github.com/yhatt/jsx-slack/pull/260))
+- Fix esm.sh resolution error by adding JSX runtimes with `.mjs` extension ([#260](https://github.com/yhatt/jsx-slack/pull/260))
 
 ## v4.5.3 - 2021-12-28
 

--- a/jsx-dev-runtime.mjs
+++ b/jsx-dev-runtime.mjs
@@ -1,0 +1,1 @@
+export * from './module/src/jsx-dev-runtime.mjs'

--- a/jsx-runtime.mjs
+++ b/jsx-runtime.mjs
@@ -1,0 +1,1 @@
+export * from './module/src/jsx-runtime.mjs'

--- a/package.json
+++ b/package.json
@@ -50,8 +50,10 @@
     "types/",
     "jsx-dev-runtime.d.ts",
     "jsx-dev-runtime.js",
+    "jsx-dev-runtime.mjs",
     "jsx-runtime.d.ts",
-    "jsx-runtime.js"
+    "jsx-runtime.js",
+    "jsx-runtime.mjs"
   ],
   "scripts": {
     "build": "rimraf lib module vendor && rollup -c",


### PR DESCRIPTION
The latest esm.sh (v59) has become no longer provided JSX runtimes from https://esm.sh/jsx-slack/jsx-runtime correctly. It seems to be finding out `jsx-runtime.js` for CommonJS instead of ESM version of JSX runtimes specified by `exports` field in `package.json` (`jsx-runtime.js` and `jsx-dev-runtime.js` had been recognized the exports kind as [`ExportsNone` instead of `ExportsESM`](https://github.com/evanw/esbuild/blob/3ec2f5470f870df3a10612d335743e63ef1f1451/internal/js_ast/js_ast.go#L1948-L1974), so they were not parsed as ES module).


This PR adds `jsx-runtime.mjs` and `jsx-dev-runtime.mjs` to make resolvable ESM version of JSX runtimes by esm.sh. I've confirmed they can find out runtimes in the dev version of esm.sh.

This change does not affect to Node.js LTS because Node.js v12.16 and later versions can recognize `exports` field and import internal modules directly.