### PR TITLE
Make build size of JSX runtime smaller 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 ### Changed
 
-- Upgrade dependent packages to the latest version ([#255](https://github.com/yhatt/jsx-slack/pull/263))
+- Upgrade dependent packages to the latest version ([#263](https://github.com/yhatt/jsx-slack/pull/263))
+- Make build size of JSX runtime smaller ([#264](https://github.com/yhatt/jsx-slack/pull/264))
 
 ## v4.5.4 - 2022-01-02
 

--- a/demo/js/convert.js
+++ b/demo/js/convert.js
@@ -1,5 +1,5 @@
 import { JSXSlack, jsxslack } from '../../src/index'
-import { isValidComponent } from '../../src/jsx'
+import { isValidComponent } from '../../src/jsx-internals'
 
 const generateUrl = (json) =>
   `https://api.slack.com/tools/block-kit-builder#${encodeURIComponent(

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -27,7 +27,13 @@ export default [
   {
     external,
     plugins,
-    input: ['src/index.ts', 'src/jsx-runtime.ts', 'src/jsx-dev-runtime.ts'],
+    input: 'src/index.ts',
+    output: { dir: 'lib', exports: 'named', format: 'cjs', compact: true },
+  },
+  {
+    external,
+    plugins,
+    input: ['src/jsx-runtime.ts', 'src/jsx-dev-runtime.ts'],
     output: { dir: 'lib', exports: 'named', format: 'cjs', compact: true },
   },
   {

--- a/rollup.prebundle.config.js
+++ b/rollup.prebundle.config.js
@@ -8,7 +8,7 @@ export const prebundleAlias = alias({
   entries: [
     {
       find: /^.*\bprebundles\/(.+)$/,
-      replacement: path.resolve(__dirname, './vendor/$1.mjs'),
+      replacement: path.resolve(__dirname, './vendor/$1.ts.mjs'),
     },
     // Node's URL dependency will never use in jsx-slack
     {
@@ -18,16 +18,23 @@ export const prebundleAlias = alias({
   ],
 })
 
+const preBundles = ['src/prebundles/hastUtilToMdast.ts', 'src/prebundles/he.ts']
+
 export const prebundleConfig = {
   plugins: [
     json({ preferConst: true }),
     esbuild({
       minify: !process.env.ROLLUP_WATCH,
       target: compilerOptions.target,
-      experimentalBundling: true,
+      optimizeDeps: {
+        include: preBundles,
+        exclude: ['node:url'],
+        esbuildOptions: { outbase: __dirname, entryNames: '[dir]/[name].ts' },
+      },
     }),
   ],
-  input: ['src/prebundles/hastUtilToMdast.ts', 'src/prebundles/he.ts'],
+  input: preBundles,
+  external: ['node:url'],
   output: {
     chunkFileNames: '[name]-[hash].mjs',
     dir: 'vendor',

--- a/src/block-kit/composition/Checkbox.ts
+++ b/src/block-kit/composition/Checkbox.ts
@@ -1,5 +1,6 @@
 import { MrkdwnElement } from '@slack/types'
-import { JSXSlack, createComponent } from '../../jsx'
+import { JSXSlack } from '../../jsx'
+import { createComponent } from '../../jsx-internals'
 import { mrkdwn, mrkdwnForOption } from './Mrkdwn'
 
 export const checkboxCheckedSymbol = Symbol('jsx-slack-checkbox-checked')

--- a/src/block-kit/composition/Confirm.ts
+++ b/src/block-kit/composition/Confirm.ts
@@ -1,5 +1,6 @@
 import { Confirm as SlackConfirm } from '@slack/types'
-import { JSXSlack, createComponent } from '../../jsx'
+import { JSXSlack } from '../../jsx'
+import { createComponent } from '../../jsx-internals'
 import { mrkdwn } from './Mrkdwn'
 import { plainText } from './utils'
 

--- a/src/block-kit/composition/Mrkdwn.tsx
+++ b/src/block-kit/composition/Mrkdwn.tsx
@@ -1,12 +1,12 @@
 /** @jsx createElementInternal */
 import { MrkdwnElement } from '@slack/types'
+import { JSXSlack } from '../../jsx'
 import {
-  JSXSlack,
   cleanMeta,
   createComponent,
   createElementInternal,
   isValidElementFromComponent,
-} from '../../jsx'
+} from '../../jsx-internals'
 import { mrkdwn as toMrkdwn } from '../../mrkdwn/index'
 import { plainText } from './utils'
 

--- a/src/block-kit/composition/Optgroup.ts
+++ b/src/block-kit/composition/Optgroup.ts
@@ -1,6 +1,7 @@
 import { PlainTextElement } from '@slack/types'
 import { JSXSlackError } from '../../error'
-import { JSXSlack, createComponent } from '../../jsx'
+import { JSXSlack } from '../../jsx'
+import { createComponent } from '../../jsx-internals'
 import { alias, resolveTagName } from '../utils'
 import { Option, OptionComposition } from './Option'
 import { plainText } from './utils'

--- a/src/block-kit/composition/Option.ts
+++ b/src/block-kit/composition/Option.ts
@@ -1,5 +1,6 @@
 import { PlainTextElement } from '@slack/types'
-import { JSXSlack, createComponent } from '../../jsx'
+import { JSXSlack } from '../../jsx'
+import { createComponent } from '../../jsx-internals'
 import { plainText } from './utils'
 
 export const optionSelectedSymbol = Symbol('jsx-slack-option-selected')

--- a/src/block-kit/composition/RadioButton.ts
+++ b/src/block-kit/composition/RadioButton.ts
@@ -1,5 +1,6 @@
 import { MrkdwnElement } from '@slack/types'
-import { JSXSlack, createComponent } from '../../jsx'
+import { JSXSlack } from '../../jsx'
+import { createComponent } from '../../jsx-internals'
 import { mrkdwn, mrkdwnForOption } from './Mrkdwn'
 
 export const radioButtonCheckedSymbol = Symbol('jsx-slack-radio-button-checked')

--- a/src/block-kit/container/Blocks.ts
+++ b/src/block-kit/container/Blocks.ts
@@ -1,4 +1,4 @@
-import type { BuiltInComponent } from '../../jsx'
+import type { BuiltInComponent } from '../../jsx-internals'
 import { Select } from '../elements/Select'
 import { Textarea } from '../input/Textarea'
 import { availableActionTypes } from '../layout/Actions'

--- a/src/block-kit/container/Home.tsx
+++ b/src/block-kit/container/Home.tsx
@@ -1,11 +1,11 @@
 /** @jsx createElementInternal */
 import { View } from '@slack/types'
+import { JSXSlack } from '../../jsx'
 import {
-  JSXSlack,
   cleanMeta,
   createComponent,
   createElementInternal,
-} from '../../jsx'
+} from '../../jsx-internals'
 import { Select } from '../elements/Select'
 import { Textarea } from '../input/Textarea'
 import { Divider } from '../layout/Divider'

--- a/src/block-kit/container/Modal.tsx
+++ b/src/block-kit/container/Modal.tsx
@@ -1,11 +1,11 @@
 /** @jsx createElementInternal */
 import { PlainTextElement, View } from '@slack/types'
+import { JSXSlack } from '../../jsx'
 import {
-  JSXSlack,
   cleanMeta,
   createComponent,
   createElementInternal,
-} from '../../jsx'
+} from '../../jsx-internals'
 import { DistributedProps } from '../../utils'
 import { plainText } from '../composition/utils'
 import { Select } from '../elements/Select'

--- a/src/block-kit/container/utils.ts
+++ b/src/block-kit/container/utils.ts
@@ -1,6 +1,7 @@
 import { ActionsBlock, Block, SectionBlock } from '@slack/types'
 import { JSXSlackError } from '../../error'
-import { JSXSlack, createComponent } from '../../jsx'
+import { JSXSlack } from '../../jsx'
+import { createComponent } from '../../jsx-internals'
 import { availableActionTypes } from '../layout/Actions'
 import { availableSectionAccessoryTypes } from '../layout/Section'
 import { alias, resolveTagName } from '../utils'

--- a/src/block-kit/elements/Button.ts
+++ b/src/block-kit/elements/Button.ts
@@ -1,5 +1,6 @@
 import { Button as ButtonElement, Confirm } from '@slack/types'
-import { JSXSlack, createComponent } from '../../jsx'
+import { JSXSlack } from '../../jsx'
+import { createComponent } from '../../jsx-internals'
 import { ConfirmableProps } from '../composition/Confirm'
 import { plainText } from '../composition/utils'
 import { assignMetaFrom } from '../utils'

--- a/src/block-kit/elements/ChannelsSelect.ts
+++ b/src/block-kit/elements/ChannelsSelect.ts
@@ -3,7 +3,7 @@ import {
   MultiChannelsSelect,
   InputBlock,
 } from '@slack/types'
-import { BuiltInComponent, createComponent } from '../../jsx'
+import { BuiltInComponent, createComponent } from '../../jsx-internals'
 import { DistributedProps, coerceToInteger } from '../../utils'
 import { ConfirmableProps } from '../composition/Confirm'
 import { plainText } from '../composition/utils'

--- a/src/block-kit/elements/CheckboxGroup.ts
+++ b/src/block-kit/elements/CheckboxGroup.ts
@@ -1,6 +1,7 @@
 import { Checkboxes as CheckboxesElement, InputBlock } from '@slack/types'
 import { JSXSlackError } from '../../error'
-import { JSXSlack, BuiltInComponent, createComponent } from '../../jsx'
+import { JSXSlack } from '../../jsx'
+import { BuiltInComponent, createComponent } from '../../jsx-internals'
 import {
   Checkbox,
   CheckboxOption,

--- a/src/block-kit/elements/ConversationsSelect.ts
+++ b/src/block-kit/elements/ConversationsSelect.ts
@@ -3,7 +3,7 @@ import {
   MultiConversationsSelect,
   InputBlock,
 } from '@slack/types'
-import { BuiltInComponent, createComponent } from '../../jsx'
+import { BuiltInComponent, createComponent } from '../../jsx-internals'
 import { DistributedProps, coerceToInteger } from '../../utils'
 import { ConfirmableProps } from '../composition/Confirm'
 import { FilterProps, filter, plainText } from '../composition/utils'

--- a/src/block-kit/elements/DatePicker.ts
+++ b/src/block-kit/elements/DatePicker.ts
@@ -1,5 +1,5 @@
 import { Datepicker, InputBlock } from '@slack/types'
-import { BuiltInComponent, createComponent } from '../../jsx'
+import { BuiltInComponent, createComponent } from '../../jsx-internals'
 import { ConfirmableProps } from '../composition/Confirm'
 import { plainText } from '../composition/utils'
 import { InputComponentProps, wrapInInput } from '../layout/Input'

--- a/src/block-kit/elements/ExternalSelect.ts
+++ b/src/block-kit/elements/ExternalSelect.ts
@@ -4,7 +4,8 @@ import {
   MultiExternalSelect,
   Option as OptionComposition,
 } from '@slack/types'
-import { JSXSlack, BuiltInComponent, createComponent } from '../../jsx'
+import { JSXSlack } from '../../jsx'
+import { BuiltInComponent, createComponent } from '../../jsx-internals'
 import { coerceToInteger } from '../../utils'
 import { ConfirmableProps } from '../composition/Confirm'
 import { OptionProps } from '../composition/Option'

--- a/src/block-kit/elements/Overflow.ts
+++ b/src/block-kit/elements/Overflow.ts
@@ -1,6 +1,7 @@
 import { PlainTextOption, Overflow as OverflowElement } from '@slack/types'
 import { JSXSlackError } from '../../error'
-import { JSXSlack, createComponent } from '../../jsx'
+import { JSXSlack } from '../../jsx'
+import { createComponent } from '../../jsx-internals'
 import { ConfirmableProps } from '../composition/Confirm'
 import { plainText } from '../composition/utils'
 import { resolveTagName } from '../utils'

--- a/src/block-kit/elements/PlainTextInput.ts
+++ b/src/block-kit/elements/PlainTextInput.ts
@@ -2,7 +2,7 @@ import {
   PlainTextInput as SlackPlainTextInput,
   DispatchActionConfig,
 } from '@slack/types'
-import { createComponent } from '../../jsx'
+import { createComponent } from '../../jsx-internals'
 import { plainText } from '../composition/utils'
 
 export interface PlainTextInputProps {

--- a/src/block-kit/elements/RadioButtonGroup.ts
+++ b/src/block-kit/elements/RadioButtonGroup.ts
@@ -1,6 +1,7 @@
 import { RadioButtons as RadioButtonsElement, InputBlock } from '@slack/types'
 import { JSXSlackError } from '../../error'
-import { JSXSlack, BuiltInComponent, createComponent } from '../../jsx'
+import { JSXSlack } from '../../jsx'
+import { BuiltInComponent, createComponent } from '../../jsx-internals'
 import { ConfirmableProps } from '../composition/Confirm'
 import {
   RadioButton,

--- a/src/block-kit/elements/Select.tsx
+++ b/src/block-kit/elements/Select.tsx
@@ -1,13 +1,13 @@
 /** @jsx createElementInternal */
 import { StaticSelect, MultiStaticSelect, InputBlock } from '@slack/types'
 import { JSXSlackError } from '../../error'
+import { JSXSlack } from '../../jsx'
 import {
-  JSXSlack,
   BuiltInComponent,
   createComponent,
   createElementInternal,
   isValidElementFromComponent,
-} from '../../jsx'
+} from '../../jsx-internals'
 import { coerceToInteger } from '../../utils'
 import { ConfirmableProps } from '../composition/Confirm'
 import { OptionComposition } from '../composition/Option'

--- a/src/block-kit/elements/TimePicker.ts
+++ b/src/block-kit/elements/TimePicker.ts
@@ -1,5 +1,5 @@
 import { InputBlock, Timepicker } from '@slack/types'
-import { BuiltInComponent, createComponent } from '../../jsx'
+import { BuiltInComponent, createComponent } from '../../jsx-internals'
 import { ConfirmableProps } from '../composition/Confirm'
 import { plainText } from '../composition/utils'
 import { InputComponentProps, wrapInInput } from '../layout/Input'

--- a/src/block-kit/elements/UsersSelect.ts
+++ b/src/block-kit/elements/UsersSelect.ts
@@ -3,7 +3,7 @@ import {
   MultiUsersSelect,
   InputBlock,
 } from '@slack/types'
-import { BuiltInComponent, createComponent } from '../../jsx'
+import { BuiltInComponent, createComponent } from '../../jsx-internals'
 import { coerceToInteger } from '../../utils'
 import { ConfirmableProps } from '../composition/Confirm'
 import { plainText } from '../composition/utils'

--- a/src/block-kit/input/Textarea.tsx
+++ b/src/block-kit/input/Textarea.tsx
@@ -1,6 +1,10 @@
 /** @jsx createElementInternal */
 import { InputBlock, PlainTextInput as SlackPlainTextInput } from '@slack/types'
-import { cleanMeta, createComponent, createElementInternal } from '../../jsx'
+import {
+  cleanMeta,
+  createComponent,
+  createElementInternal,
+} from '../../jsx-internals'
 import { coerceToInteger } from '../../utils'
 import { inputDispatchActionConfig } from '../composition/utils'
 import { PlainTextInput } from '../elements/PlainTextInput'

--- a/src/block-kit/layout/Actions.ts
+++ b/src/block-kit/layout/Actions.ts
@@ -1,6 +1,7 @@
 import { ActionsBlock, Action } from '@slack/types'
 import { JSXSlackError } from '../../error'
-import { JSXSlack, createComponent } from '../../jsx'
+import { JSXSlack } from '../../jsx'
+import { createComponent } from '../../jsx-internals'
 import { Button } from '../elements/Button'
 import { Select } from '../elements/Select'
 import { alias, resolveTagName } from '../utils'

--- a/src/block-kit/layout/Call.ts
+++ b/src/block-kit/layout/Call.ts
@@ -1,5 +1,5 @@
 import { Block } from '@slack/types'
-import { createComponent } from '../../jsx'
+import { createComponent } from '../../jsx-internals'
 import { LayoutBlockProps } from './utils'
 
 type CallBlock = Block & {

--- a/src/block-kit/layout/Context.ts
+++ b/src/block-kit/layout/Context.ts
@@ -1,6 +1,7 @@
 import { ContextBlock, ImageElement, MrkdwnElement } from '@slack/types'
 import { JSXSlackError } from '../../error'
-import { createComponent, JSXSlack } from '../../jsx'
+import { JSXSlack } from '../../jsx'
+import { createComponent } from '../../jsx-internals'
 import { mrkdwn } from '../composition/Mrkdwn'
 import { assignMetaFrom } from '../utils'
 import { LayoutBlockProps } from './utils'

--- a/src/block-kit/layout/Divider.ts
+++ b/src/block-kit/layout/Divider.ts
@@ -1,5 +1,5 @@
 import { DividerBlock } from '@slack/types'
-import { createComponent } from '../../jsx'
+import { createComponent } from '../../jsx-internals'
 import { LayoutBlockProps } from './utils'
 
 export interface DividerProps extends LayoutBlockProps {

--- a/src/block-kit/layout/File.ts
+++ b/src/block-kit/layout/File.ts
@@ -1,5 +1,5 @@
 import { FileBlock } from '@slack/types'
-import { createComponent } from '../../jsx'
+import { createComponent } from '../../jsx-internals'
 import { LayoutBlockProps } from './utils'
 
 export interface FileProps extends LayoutBlockProps {

--- a/src/block-kit/layout/Header.ts
+++ b/src/block-kit/layout/Header.ts
@@ -1,5 +1,6 @@
 import { HeaderBlock } from '@slack/types'
-import { JSXSlack, createComponent } from '../../jsx'
+import { JSXSlack } from '../../jsx'
+import { createComponent } from '../../jsx-internals'
 import { plainText } from '../composition/utils'
 import { LayoutBlockProps } from './utils'
 

--- a/src/block-kit/layout/Image.ts
+++ b/src/block-kit/layout/Image.ts
@@ -1,5 +1,5 @@
 import { ImageBlock } from '@slack/types'
-import { createComponent } from '../../jsx'
+import { createComponent } from '../../jsx-internals'
 import { plainText } from '../composition/utils'
 import { LayoutBlockProps } from './utils'
 

--- a/src/block-kit/layout/Input.tsx
+++ b/src/block-kit/layout/Input.tsx
@@ -1,13 +1,13 @@
 /** @jsx createElementInternal */
 import { InputBlock as _InputBlock } from '@slack/types'
 import { JSXSlackError } from '../../error'
+import { JSXSlack } from '../../jsx'
 import {
-  JSXSlack,
   cleanMeta,
   createComponent,
   createElementInternal,
   BuiltInComponent,
-} from '../../jsx'
+} from '../../jsx-internals'
 import { DistributedProps, coerceToInteger } from '../../utils'
 import {
   plainText,

--- a/src/block-kit/layout/Section.ts
+++ b/src/block-kit/layout/Section.ts
@@ -1,7 +1,8 @@
 /* eslint-disable @typescript-eslint/no-empty-function */
 import { SectionBlock, MrkdwnElement } from '@slack/types'
 import { JSXSlackError } from '../../error'
-import { JSXSlack, createComponent } from '../../jsx'
+import { JSXSlack } from '../../jsx'
+import { createComponent } from '../../jsx-internals'
 import { Escape } from '../../mrkdwn/jsx'
 import { mrkdwn } from '../composition/Mrkdwn'
 import { Button } from '../elements/Button'

--- a/src/block-kit/layout/utils.ts
+++ b/src/block-kit/layout/utils.ts
@@ -1,5 +1,5 @@
 import { JSXSlackError } from '../../error'
-import { isValidElementFromComponent } from '../../jsx'
+import { isValidElementFromComponent } from '../../jsx-internals'
 import { resolveTagName } from '../utils'
 
 export interface LayoutBlockProps {

--- a/src/block-kit/other/SelectFragment.ts
+++ b/src/block-kit/other/SelectFragment.ts
@@ -1,5 +1,6 @@
 import { JSXSlackError } from '../../error'
-import { JSXSlack, BuiltInComponent, createComponent } from '../../jsx'
+import { JSXSlack } from '../../jsx'
+import { BuiltInComponent, createComponent } from '../../jsx-internals'
 import { Optgroup, OptgroupComposition } from '../composition/Optgroup'
 import {
   Option,

--- a/src/block-kit/utils.ts
+++ b/src/block-kit/utils.ts
@@ -1,9 +1,9 @@
+import { JSXSlack } from '../jsx'
 import {
-  JSXSlack,
   cleanMeta,
   createElementInternal,
   isValidComponent,
-} from '../jsx'
+} from '../jsx-internals'
 
 export const assignMetaFrom = <T extends object>(
   element: JSXSlack.Node,

--- a/src/jsx-internals.ts
+++ b/src/jsx-internals.ts
@@ -72,7 +72,7 @@ export const createComponent = <P extends {}, O extends object>(
   Object.defineProperty(component as any, '$$jsxslackComponent', {
     value: Object.freeze(
       Object.defineProperty({ ...meta }, 'name', {
-        value: name || '[Anonymous component]',
+        value: name,
         enumerable: true,
       })
     ),

--- a/src/jsx-internals.ts
+++ b/src/jsx-internals.ts
@@ -1,0 +1,143 @@
+/* eslint-disable @typescript-eslint/ban-types */
+import type { JSXSlack } from './jsx'
+
+export interface BuiltInComponent<P extends {}> extends JSXSlack.FC<P> {
+  readonly $$jsxslackComponent: { name: string } & Record<any, any>
+}
+
+export const createElementInternal = (
+  type: JSXSlack.FC | keyof JSXSlack.JSX.IntrinsicElements,
+  props: JSXSlack.Props | null = null,
+  ...children: JSXSlack.ChildElement[]
+): JSXSlack.JSX.Element | null => {
+  let rendered: JSXSlack.Node | null = Object.create(null)
+
+  if (typeof type === 'function') {
+    const p = { ...(props || {}) }
+
+    if (children.length === 1) [p.children] = children
+    else if (children.length > 1) p.children = children
+
+    rendered = type(p)
+  }
+
+  if (rendered && typeof rendered === 'object') {
+    // Apply JSON normalization
+    for (const key of Object.keys(rendered)) {
+      if (rendered[key] === undefined) delete rendered[key]
+    }
+
+    if (!rendered.$$jsxslack) {
+      // Children in metadata must be an array
+      let metaChildren = children
+
+      if (children.length === 0) {
+        // Fallback to children props
+        const { children: propsChildren } = props || {}
+        if (propsChildren !== undefined) metaChildren = [].concat(propsChildren)
+      }
+
+      Object.defineProperty(rendered, '$$jsxslack', {
+        value: { type, props, children: metaChildren },
+      })
+    }
+  }
+
+  return rendered
+}
+
+/**
+ * Create the component for JSON payload building with jsx-slack.
+ *
+ * The passed functional component has to return JSON object or `null`, to build
+ * JSON payload for Slack. Unlike a simple functional component defined by
+ * JavaScript function, the output would be always preserved in JSON even if it
+ * was an array.
+ *
+ * @remarks
+ * `createComponent()` is an internal helper to create built-in components for
+ * jsx-slack. Typically user must use a simple function definition of JavaScript
+ * to create the functional component.
+ *
+ * @param name - Component name for showing in debug log
+ * @param component - The functional component to turn into jsx-slack component
+ * @param meta - An optional metadata for jsx-slack component
+ * @return A created jsx-slack component
+ */
+export const createComponent = <P extends {}, O extends object>(
+  name: string,
+  component: (props: JSXSlack.Props<P>) => O | null,
+  meta: Record<any, any> = {}
+): BuiltInComponent<P> =>
+  Object.defineProperty(component as any, '$$jsxslackComponent', {
+    value: Object.freeze(
+      Object.defineProperty({ ...meta }, 'name', {
+        value: name || '[Anonymous component]',
+        enumerable: true,
+      })
+    ),
+  })
+
+export const FragmentInternal = createComponent<
+  { children: JSXSlack.ChildElements },
+  JSXSlack.ChildElement[]
+>('Fragment', ({ children }) =>
+  // Should return array's shallow copy to remove metadata from array
+  ([] as JSXSlack.ChildElement[]).concat(children)
+)
+
+/**
+ * Verify the passed function is a jsx-slack component.
+ *
+ * @param fn - A function to verify
+ * @return `true` if the passed object was a jsx-slack component., otherwise
+ *   `false`
+ */
+export const isValidComponent = <T = any>(
+  fn: unknown
+): fn is BuiltInComponent<T> =>
+  typeof fn === 'function' &&
+  !!Object.prototype.hasOwnProperty.call(fn, '$$jsxslackComponent')
+
+export const isValidElementInternal = (
+  obj: unknown
+): obj is JSXSlack.JSX.Element =>
+  typeof obj === 'object' &&
+  !!obj &&
+  !!Object.prototype.hasOwnProperty.call(obj, '$$jsxslack')
+
+/**
+ * Verify the passed object is a jsx-slack element created from built-in
+ * component.
+ *
+ * @param element - An object to verify
+ * @param component - The optional component to match while verifying
+ * @return `true` if the passed object was a jsx-slack element created from
+ *   built-in component, otherwise `false`
+ */
+export const isValidElementFromComponent = (
+  obj: unknown,
+  component?: JSXSlack.FunctionalComponent<any>
+): obj is JSXSlack.JSX.Element =>
+  isValidElementInternal(obj) &&
+  isValidComponent(obj.$$jsxslack.type) &&
+  (!component || obj.$$jsxslack.type === component)
+
+/**
+ * Clean up hidden meta value for jsx-slack from object.
+ *
+ * If the built-in component has nested JSX output such as alias, a hidden
+ * metadata can reference an internal JSX from the public partial object. An
+ * internal would not matter for jsx-slack user, so the error message displaying
+ * private JSX info may confuse.
+ *
+ * It just re-assigns public objects into new object, but this helper makes
+ * clear its purpose.
+ *
+ * @param element - The object with meta value for jsx-slack
+ * @return The object without meta value
+ */
+export const cleanMeta = <T extends object>(
+  element: T
+): T extends Array<infer R> ? Array<R> : Omit<T, keyof JSXSlack.Node> =>
+  (Array.isArray(element) ? [...element] : { ...element }) as any

--- a/src/jsx-runtime.ts
+++ b/src/jsx-runtime.ts
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/no-namespace, @typescript-eslint/no-empty-interface */
-import { JSXSlack, createElementInternal, FragmentInternal } from './jsx'
+import { JSXSlack } from './jsx'
+import { createElementInternal, FragmentInternal } from './jsx-internals'
 
 export const jsx = (type: any, props: Record<string, unknown>, key: any) =>
   createElementInternal(type ?? FragmentInternal, {

--- a/src/jsx.ts
+++ b/src/jsx.ts
@@ -10,10 +10,12 @@ import { HeaderProps } from './block-kit/layout/Header'
 import { ImageProps } from './block-kit/layout/Image'
 import { InputProps } from './block-kit/layout/Input'
 import { SectionProps } from './block-kit/layout/Section'
-
-export interface BuiltInComponent<P extends {}> extends JSXSlack.FC<P> {
-  readonly $$jsxslackComponent: { name: string } & Record<any, any>
-}
+import {
+  FragmentInternal,
+  createElementInternal,
+  isValidElementInternal,
+  isValidElementFromComponent,
+} from './jsx-internals'
 
 /**
  * The helper function to cast the output type from JSX element to `any`. Just
@@ -28,142 +30,6 @@ export interface BuiltInComponent<P extends {}> extends JSXSlack.FC<P> {
 export function JSXSlack(element: JSXSlack.JSX.Element): any {
   return element
 }
-
-/** @internal */
-export const createElementInternal = (
-  type: JSXSlack.FC | keyof JSXSlack.JSX.IntrinsicElements,
-  props: JSXSlack.Props | null = null,
-  ...children: JSXSlack.ChildElement[]
-): JSXSlack.JSX.Element | null => {
-  let rendered: JSXSlack.Node | null = Object.create(null)
-
-  if (typeof type === 'function') {
-    const p = { ...(props || {}) }
-
-    if (children.length === 1) [p.children] = children
-    else if (children.length > 1) p.children = children
-
-    rendered = type(p)
-  }
-
-  if (rendered && typeof rendered === 'object') {
-    // Apply JSON normalization
-    for (const key of Object.keys(rendered)) {
-      if (rendered[key] === undefined) delete rendered[key]
-    }
-
-    if (!rendered.$$jsxslack) {
-      // Children in metadata must be an array
-      let metaChildren = children
-
-      if (children.length === 0) {
-        // Fallback to children props
-        const { children: propsChildren } = props || {}
-        if (propsChildren !== undefined) metaChildren = [].concat(propsChildren)
-      }
-
-      Object.defineProperty(rendered, '$$jsxslack', {
-        value: { type, props, children: metaChildren },
-      })
-    }
-  }
-
-  return rendered
-}
-
-/**
- * Create the component for JSON payload building with jsx-slack.
- *
- * The passed functional component has to return JSON object or `null`, to build
- * JSON payload for Slack. Unlike a simple functional component defined by
- * JavaScript function, the output would be always preserved in JSON even if it
- * was an array.
- *
- * @remarks
- * `createComponent()` is an internal helper to create built-in components for
- * jsx-slack. Typically user must use a simple function definition of JavaScript
- * to create the functional component.
- *
- * @internal
- * @param name - Component name for showing in debug log
- * @param component - The functional component to turn into jsx-slack component
- * @param meta - An optional metadata for jsx-slack component
- * @return A created jsx-slack component
- */
-export const createComponent = <P extends {}, O extends object>(
-  name: string,
-  component: (props: JSXSlack.Props<P>) => O | null,
-  meta: Record<any, any> = {}
-): BuiltInComponent<P> =>
-  Object.defineProperty(component as any, '$$jsxslackComponent', {
-    value: Object.freeze(
-      Object.defineProperty({ ...meta }, 'name', {
-        value: name || '[Anonymous component]',
-        enumerable: true,
-      })
-    ),
-  })
-
-/** @internal */
-export const FragmentInternal = createComponent<
-  { children: JSXSlack.ChildElements },
-  JSXSlack.ChildElement[]
->('Fragment', ({ children }) =>
-  // Should return array's shallow copy to remove metadata from array
-  ([] as JSXSlack.ChildElement[]).concat(children)
-)
-
-/**
- * Verify the passed function is a jsx-slack component.
- *
- * @internal
- * @param fn - A function to verify
- * @return `true` if the passed object was a jsx-slack component., otherwise
- *   `false`
- */
-export const isValidComponent = <T = any>(
-  fn: unknown
-): fn is BuiltInComponent<T> =>
-  typeof fn === 'function' &&
-  !!Object.prototype.hasOwnProperty.call(fn, '$$jsxslackComponent')
-
-/**
- * Verify the passed object is a jsx-slack element created from built-in
- * component.
- *
- * @internal
- * @param element - An object to verify
- * @param component - The optional component to match while verifying
- * @return `true` if the passed object was a jsx-slack element created from
- *   built-in component, otherwise `false`
- */
-export const isValidElementFromComponent = (
-  obj: unknown,
-  component?: JSXSlack.FunctionalComponent<any>
-): obj is JSXSlack.JSX.Element =>
-  JSXSlack.isValidElement(obj) &&
-  isValidComponent(obj.$$jsxslack.type) &&
-  (!component || obj.$$jsxslack.type === component)
-
-/**
- * Clean up hidden meta value for jsx-slack from object.
- *
- * If the built-in component has nested JSX output such as alias, a hidden
- * metadata can reference an internal JSX from the public partial object. An
- * internal would not matter for jsx-slack user, so the error message displaying
- * private JSX info may confuse.
- *
- * It just re-assigns public objects into new object, but this helper makes
- * clear its purpose.
- *
- * @internal
- * @param element - The object with meta value for jsx-slack
- * @return The object without meta value
- */
-export const cleanMeta = <T extends object>(
-  element: T
-): T extends Array<infer R> ? Array<R> : Omit<T, keyof JSXSlack.Node> =>
-  (Array.isArray(element) ? [...element] : { ...element }) as any
 
 export namespace JSXSlack {
   interface StringLike {
@@ -233,10 +99,7 @@ export namespace JSXSlack {
    * @return `true` if the passed object was a jsx-slack element, otherwise
    *   `false`
    */
-  export const isValidElement = (obj: unknown): obj is JSXSlack.JSX.Element =>
-    typeof obj === 'object' &&
-    !!obj &&
-    !!Object.prototype.hasOwnProperty.call(obj, '$$jsxslack')
+  export const isValidElement = isValidElementInternal
 
   /**
    * Create and return a new jsx-slack element of the given type.

--- a/src/mrkdwn/jsx.ts
+++ b/src/mrkdwn/jsx.ts
@@ -1,6 +1,7 @@
 import formatDate from '../date'
 import { JSXSlackError } from '../error'
-import { JSXSlack, createComponent } from '../jsx'
+import { JSXSlack } from '../jsx'
+import { createComponent } from '../jsx-internals'
 import { detectSpecialLink } from '../utils'
 import {
   escapeChars,

--- a/src/tag.ts
+++ b/src/tag.ts
@@ -1,6 +1,6 @@
 import htm from 'htm/mini'
 import * as blockKitComponents from './components'
-import { createElementInternal } from './jsx'
+import { createElementInternal } from './jsx-internals'
 import { he } from './prebundles/he'
 
 type JSXSlackTemplateTag = (

--- a/test/jsx.tsx
+++ b/test/jsx.tsx
@@ -5,12 +5,12 @@ import type {
   VFC,
   VoidFunctionComponent,
 } from '../src/index'
+import { JSXSlack } from '../src/jsx'
 import {
-  JSXSlack,
   createComponent,
   isValidComponent,
   isValidElementFromComponent,
-} from '../src/jsx'
+} from '../src/jsx-internals'
 
 describe('JSX', () => {
   describe('JSXSlack()', () => {


### PR DESCRIPTION
Make build size of JSX runtime smaller by splitting internal methods for JSX into another file.

`JSXSlack` namespace within `jsx.ts` was not tree shakeable so the output size of JSX runtime has bloated. In this PR, internal methods for JSX runtime has splitted into `jsx-internals.ts`.

By this change, the bundle size of JSX runtime will shrink from 1786 bytes to 772 bytes.