### PR TITLE
[v5] Make compatible types with React 18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 ## [Unreleased]
 
+### Breaking
+
+- Removed implicit `children` prop from `FunctionComponent` to make compatible types with React 18 (Use `PropsWithChildren<P>` to include `children` prop) ([#270](https://github.com/yhatt/jsx-slack/pull/270))
+
+  ```diff
+  -JSXSlack.FunctionComponent<P>
+  +JSXSlack.FunctionComponent<JSXSlack.PropsWithChildren<P>>
+  -JSXSlack.FunctionComponent
+  +JSXSlack.FunctionComponent<JSXSlack.PropsWithChildren<{}>>
+  ```
+
+### Deprecated
+
+- `VoidFunctionComponent`, `VFC`, `FunctionalComponent`, `VoidFunctionalComponent`, and `Props` type ([#270](https://github.com/yhatt/jsx-slack/pull/270))
+
+  |           Depreacted            |         Replace to         |
+  | :-----------------------------: | :------------------------: |
+  | `VoidFunctionComponent` / `VFC` | `FunctionComponent` / `FC` |
+  |      `FunctionalComponent`      | `FunctionComponent` / `FC` |
+  |    `VoidFunctionalComponent`    | `FunctionComponent` / `FC` |
+  |           `Props<P>`            |            `P`             |
+
 ## v4.6.1 - 2022-03-28
 
 ### Fixed

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,14 +8,13 @@ export default JSXSlack
 
 // Useful type aliases that are similar to @types/react
 export type Node = JSXSlack.ChildElements
-export type FunctionComponent<P extends {} = Record<any, never>> =
-  JSXSlack.FunctionComponent<P>
-export type FC<P extends {} = Record<any, never>> = JSXSlack.FC<P>
+export type FunctionComponent<P extends {} = {}> = JSXSlack.FunctionComponent<P>
+export type FC<P extends {} = {}> = JSXSlack.FC<P>
 export type PropsWithChildren<P extends {} = {}> = JSXSlack.PropsWithChildren<P>
 
 /** @deprecated Use FunctionComponent instead. */
-export type VoidFunctionComponent<P extends {} = Record<any, never>> =
+export type VoidFunctionComponent<P extends {} = {}> =
   JSXSlack.VoidFunctionComponent<P>
 
 /** @deprecated Use FunctionComponent instead. */
-export type VFC<P extends {} = Record<any, never>> = JSXSlack.VFC<P>
+export type VFC<P extends {} = {}> = JSXSlack.VFC<P>

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,8 +8,14 @@ export default JSXSlack
 
 // Useful type aliases that are similar to @types/react
 export type Node = JSXSlack.ChildElements
-export type FunctionComponent<P extends {} = {}> = JSXSlack.FunctionComponent<P>
-export type FC<P extends {} = {}> = JSXSlack.FC<P>
+export type FunctionComponent<P extends {} = Record<any, never>> =
+  JSXSlack.FunctionComponent<P>
+export type FC<P extends {} = Record<any, never>> = JSXSlack.FC<P>
+export type PropsWithChildren<P extends {} = {}> = JSXSlack.PropsWithChildren<P>
+
+/** @deprecated Use FunctionComponent instead. */
 export type VoidFunctionComponent<P extends {} = Record<any, never>> =
   JSXSlack.VoidFunctionComponent<P>
+
+/** @deprecated Use FunctionComponent instead. */
 export type VFC<P extends {} = Record<any, never>> = JSXSlack.VFC<P>

--- a/src/jsx-internals.ts
+++ b/src/jsx-internals.ts
@@ -16,15 +16,17 @@ export interface BuiltInComponent<P extends {}> extends JSXSlack.FC<P> {
   readonly $$jsxslackComponent: { name: string } & Record<any, any>
 }
 
-export const createElementInternal = (
-  type: JSXSlack.FC | keyof JSXSlack.JSX.IntrinsicElements,
-  props: JSXSlack.Props | null = null,
+export const createElementInternal = <P extends {} = {}>(
+  type:
+    | JSXSlack.FC<JSXSlack.PropsWithChildren<P>>
+    | keyof JSXSlack.JSX.IntrinsicElements,
+  props: JSXSlack.PropsWithChildren<P> | null = null,
   ...children: JSXSlack.ChildElement[]
 ): JSXSlack.JSX.Element | null => {
   let rendered: JSXSlack.Node | null = objectCreate(null)
 
   if (typeof type === 'function') {
-    let p = { ...(props || {}) }
+    let p = { ...(props || {}) } as JSXSlack.PropsWithChildren<P>
     let { length } = children
 
     if (length === 1) [p.children] = children
@@ -46,7 +48,9 @@ export const createElementInternal = (
       if (!children.length) {
         // Fallback to children props
         let { children: propsChildren } = props || {}
-        if (propsChildren !== undefined) metaChildren = [].concat(propsChildren)
+        if (propsChildren !== undefined) {
+          metaChildren = ([] as JSXSlack.ChildElement[]).concat(propsChildren)
+        }
       }
 
       defineProperty(rendered, jsxSlackObjKey, {
@@ -78,7 +82,7 @@ export const createElementInternal = (
  */
 export const createComponent = <P extends {}, O extends object>(
   name: string,
-  component: (props: JSXSlack.Props<P>) => O | null,
+  component: (props: P) => O | null,
   meta: Record<any, any> = {}
 ): BuiltInComponent<P> =>
   defineProperty(component as any, jsxSlackComponentObjKey, {
@@ -129,7 +133,7 @@ export const isValidElementInternal = (
  */
 export const isValidElementFromComponent = (
   obj: unknown,
-  component?: JSXSlack.FunctionalComponent<any>
+  component?: JSXSlack.FunctionComponent<any>
 ): obj is JSXSlack.JSX.Element =>
   isValidElementInternal(obj) &&
   isValidComponent(obj[jsxSlackObjKey].type) &&

--- a/src/jsx-internals.ts
+++ b/src/jsx-internals.ts
@@ -17,16 +17,14 @@ export interface BuiltInComponent<P extends {}> extends JSXSlack.FC<P> {
 }
 
 export const createElementInternal = <P extends {} = {}>(
-  type:
-    | JSXSlack.FC<JSXSlack.PropsWithChildren<P>>
-    | keyof JSXSlack.JSX.IntrinsicElements,
-  props: JSXSlack.PropsWithChildren<P> | null = null,
+  type: JSXSlack.FC<P> | keyof JSXSlack.JSX.IntrinsicElements,
+  props: P | null = null,
   ...children: JSXSlack.ChildElement[]
 ): JSXSlack.JSX.Element | null => {
-  let rendered: JSXSlack.Node | null = objectCreate(null)
+  let rendered: JSXSlack.Node<P> | null = objectCreate(null)
 
   if (typeof type === 'function') {
-    let p = { ...(props || {}) } as JSXSlack.PropsWithChildren<P>
+    let p: JSXSlack.PropsWithChildren<P> = { ...(props || ({} as P)) }
     let { length } = children
 
     if (length === 1) [p.children] = children
@@ -47,7 +45,8 @@ export const createElementInternal = <P extends {} = {}>(
 
       if (!children.length) {
         // Fallback to children props
-        let { children: propsChildren } = props || {}
+        let { children: propsChildren } =
+          (props as JSXSlack.PropsWithChildren<P>) || {}
         if (propsChildren !== undefined) {
           metaChildren = ([] as JSXSlack.ChildElement[]).concat(propsChildren)
         }
@@ -106,8 +105,8 @@ export const FragmentInternal = createComponent<
  * Verify the passed function is a jsx-slack component.
  *
  * @param fn - A function to verify
- * @return `true` if the passed object was a jsx-slack component., otherwise
- *   `false`
+ * @return `true` if the passed object was a jsx-slack component, otherwise
+ *   `false`.
  */
 export const isValidComponent = <T = any>(
   fn: unknown

--- a/src/jsx.ts
+++ b/src/jsx.ts
@@ -66,25 +66,20 @@ export namespace JSXSlack {
     children?: ChildElements
   } & P
 
-  export type FunctionComponent<P extends {} = Record<any, never>> = (
-    props: P
-  ) => Node | null
-  export type FC<P extends {} = Record<any, never>> = FunctionComponent<P>
+  export type FunctionComponent<P extends {} = {}> = (props: P) => Node | null
+  export type FC<P extends {} = {}> = FunctionComponent<P>
 
   // Legacy aliases for FC
   /** @deprecated Use a original type instead. */
-  export type Props<P extends {} = Record<any, never>> = P
+  export type Props<P extends {} = {}> = P
   /** @deprecated Use FunctionComponent instead. */
-  export type FunctionalComponent<P extends {} = Record<any, never>> =
-    FunctionComponent<P>
+  export type FunctionalComponent<P extends {} = {}> = FunctionComponent<P>
   /** @deprecated Use FunctionComponent instead. */
-  export type VoidFunctionComponent<P extends {} = Record<any, never>> =
-    FunctionComponent<P>
+  export type VoidFunctionComponent<P extends {} = {}> = FunctionComponent<P>
   /** @deprecated Use FunctionComponent instead. */
-  export type VFC<P extends {} = Record<any, never>> = FunctionComponent<P>
+  export type VFC<P extends {} = {}> = FunctionComponent<P>
   /** @deprecated Use FunctionComponent instead. */
-  export type VoidFunctionalComponent<P extends {} = Record<any, never>> =
-    FunctionComponent<P>
+  export type VoidFunctionalComponent<P extends {} = {}> = FunctionComponent<P>
 
   export interface Node<P extends {} = any> {
     /**

--- a/src/jsx.ts
+++ b/src/jsx.ts
@@ -62,23 +62,29 @@ export namespace JSXSlack {
     index: number
   ) => T
 
-  export type Props<P = any> = { children?: ChildElements } & P
+  export type PropsWithChildren<P extends {} = {}> = {
+    children?: ChildElements
+  } & P
 
-  export type FunctionalComponent<P extends {} = {}> = (
-    props: Props<P>
-  ) => Node | null
-
-  export type FunctionComponent<P extends {} = {}> = FunctionalComponent<P>
-  export type FC<P extends {} = {}> = FunctionalComponent<P>
-
-  export type VoidFunctionalComponent<P extends {} = Record<any, never>> = (
+  export type FunctionComponent<P extends {} = Record<any, never>> = (
     props: P
   ) => Node | null
+  export type FC<P extends {} = Record<any, never>> = FunctionComponent<P>
 
+  // Legacy aliases for FC
+  /** @deprecated Use a original type instead. */
+  export type Props<P extends {} = Record<any, never>> = P
+  /** @deprecated Use FunctionComponent instead. */
+  export type FunctionalComponent<P extends {} = Record<any, never>> =
+    FunctionComponent<P>
+  /** @deprecated Use FunctionComponent instead. */
   export type VoidFunctionComponent<P extends {} = Record<any, never>> =
-    VoidFunctionalComponent<P>
-  export type VFC<P extends {} = Record<any, never>> =
-    VoidFunctionalComponent<P>
+    FunctionComponent<P>
+  /** @deprecated Use FunctionComponent instead. */
+  export type VFC<P extends {} = Record<any, never>> = FunctionComponent<P>
+  /** @deprecated Use FunctionComponent instead. */
+  export type VoidFunctionalComponent<P extends {} = Record<any, never>> =
+    FunctionComponent<P>
 
   export interface Node<P extends {} = any> {
     /**
@@ -87,7 +93,7 @@ export namespace JSXSlack {
      */
     readonly $$jsxslack: {
       type: FC<P> | string
-      props: Props<P>
+      props: PropsWithChildren<P>
       children: ChildElement[]
     }
   }

--- a/src/jsx.ts
+++ b/src/jsx.ts
@@ -66,11 +66,13 @@ export namespace JSXSlack {
     children?: ChildElements
   } & P
 
-  export type FunctionComponent<P extends {} = {}> = (props: P) => Node | null
+  export type FunctionComponent<P extends {} = {}> = (
+    props: P
+  ) => Node<P> | null
   export type FC<P extends {} = {}> = FunctionComponent<P>
 
   // Legacy aliases for FC
-  /** @deprecated Use a original type instead. */
+  /** @deprecated Use an original type instead. */
   export type Props<P extends {} = {}> = P
   /** @deprecated Use FunctionComponent instead. */
   export type FunctionalComponent<P extends {} = {}> = FunctionComponent<P>
@@ -81,14 +83,14 @@ export namespace JSXSlack {
   /** @deprecated Use FunctionComponent instead. */
   export type VoidFunctionalComponent<P extends {} = {}> = FunctionComponent<P>
 
-  export interface Node<P extends {} = any> {
+  export interface Node<P extends {} = {}> {
     /**
      * @internal
      * **⚠️ This is an internal member of jsx-slack. ⚠️** Not recommend to use.
      */
     readonly $$jsxslack: {
       type: FC<P> | string
-      props: PropsWithChildren<P>
+      props: P
       children: ChildElement[]
     }
   }
@@ -288,7 +290,7 @@ export namespace JSXSlack {
   }
 
   export namespace JSX {
-    export interface Element extends Node {}
+    export interface Element extends Node<any> {}
     export interface IntrinsicElements {
       /** An HTML-compatible alias into `<Header>` layout block. */
       header: HeaderProps

--- a/test/block-kit/container-components.tsx
+++ b/test/block-kit/container-components.tsx
@@ -99,14 +99,20 @@ describe('Container components', () => {
       let blocks: any
 
       expect(() => {
-        blocks = (
-          // @ts-expect-error
-          <Blocks>
-            Hello
-            {falseyStr && <Section>test</Section>}
-            {falseyNum && <Section>test</Section>}
-          </Blocks>
-        )
+        // @ts-expect-error
+        blocks = <Blocks>Hello</Blocks>
+      }).not.toThrow()
+      expect(blocks).toStrictEqual([])
+
+      expect(() => {
+        // @ts-expect-error
+        blocks = <Blocks>{falseyStr && <Section>test</Section>}</Blocks>
+      }).not.toThrow()
+      expect(blocks).toStrictEqual([])
+
+      expect(() => {
+        // @ts-expect-error
+        blocks = <Blocks>{falseyNum && <Section>test</Section>}</Blocks>
       }).not.toThrow()
       expect(blocks).toStrictEqual([])
     })
@@ -182,14 +188,20 @@ describe('Container components', () => {
       let modal: any
 
       expect(() => {
-        modal = (
-          // @ts-expect-error
-          <Modal title="title">
-            Hello
-            {falseyStr && <Section>test</Section>}
-            {falseyNum && <Section>test</Section>}
-          </Modal>
-        )
+        // @ts-expect-error
+        modal = <Modal title="x">Hello</Modal>
+      }).not.toThrow()
+      expect(modal.blocks).toStrictEqual([])
+
+      expect(() => {
+        // @ts-expect-error
+        modal = <Modal title="x">{falseyStr && <Section>test</Section>}</Modal>
+      }).not.toThrow()
+      expect(modal.blocks).toStrictEqual([])
+
+      expect(() => {
+        // @ts-expect-error
+        modal = <Modal title="x">{falseyNum && <Section>test</Section>}</Modal>
       }).not.toThrow()
       expect(modal.blocks).toStrictEqual([])
     })
@@ -454,14 +466,20 @@ describe('Container components', () => {
       let home: any
 
       expect(() => {
-        home = (
-          // @ts-expect-error
-          <Home>
-            Hello
-            {falseyStr && <Section>test</Section>}
-            {falseyNum && <Section>test</Section>}
-          </Home>
-        )
+        // @ts-expect-error
+        home = <Home>Hello</Home>
+      }).not.toThrow()
+      expect(home.blocks).toStrictEqual([])
+
+      expect(() => {
+        // @ts-expect-error
+        home = <Home>{falseyStr && <Section>test</Section>}</Home>
+      }).not.toThrow()
+      expect(home.blocks).toStrictEqual([])
+
+      expect(() => {
+        // @ts-expect-error
+        home = <Home>{falseyNum && <Section>test</Section>}</Home>
       }).not.toThrow()
       expect(home.blocks).toStrictEqual([])
     })

--- a/test/jsx.tsx
+++ b/test/jsx.tsx
@@ -1,10 +1,5 @@
 /** @jsx JSXSlack.h */
-import type {
-  FC,
-  FunctionComponent,
-  VFC,
-  VoidFunctionComponent,
-} from '../src/index'
+import type { FC, FunctionComponent } from '../src/index'
 import { JSXSlack } from '../src/jsx'
 import {
   createComponent,
@@ -263,9 +258,8 @@ describe('JSX', () => {
   })
 
   describe('Types', () => {
-    describe('JSXSlack.FunctionalComponent / (JSXSlack.)FunctionComponent / (JSXSlack.)FC', () => {
-      it('accepts specified props and children', () => {
-        const functionalComponent: JSXSlack.FunctionalComponent = () => null
+    describe('JSXSlack.FunctionComponent / JSXSlack.FC', () => {
+      it('accepts only specified props', () => {
         const functionComponent: JSXSlack.FunctionComponent = () => null
         const fc: JSXSlack.FC<{ test: string }> = ({ test }) => (
           <JSXSlack.Fragment>{test}</JSXSlack.Fragment>
@@ -273,54 +267,25 @@ describe('JSX', () => {
         const publicFunctionComponent: FunctionComponent<{ test: string }> = ({
           test,
         }) => <JSXSlack.Fragment>{test}</JSXSlack.Fragment>
-        const publicFC: FC<{}> = () => null // eslint-disable-line @typescript-eslint/ban-types
+        const publicFC: FC<Record<string, never>> = () => null
 
-        expect(functionalComponent({ children: [] })).toBeNull()
+        // @ts-expect-error children prop is not allowed in FunctionComponent
         expect(functionComponent({ children: [] })).toBeNull()
+        expect(functionComponent({})).toBeNull()
+
+        // @ts-expect-error children prop is not allowed in FunctionComponent
         expect(fc({ test: 'abc', children: [] })).toStrictEqual(['abc'])
+        expect(fc({ test: 'abc' })).toStrictEqual(['abc'])
+
         expect(
+          // @ts-expect-error children prop is not allowed in FunctionComponent
           publicFunctionComponent({ test: 'def', children: [] })
         ).toStrictEqual(['def'])
+        expect(publicFunctionComponent({ test: 'def' })).toStrictEqual(['def'])
+
+        // @ts-expect-error children prop is not allowed in FunctionComponent
         expect(publicFC({ children: [] })).toBeNull()
-      })
-    })
-
-    describe('JSXSlack.VoidFunctionalComponent / (JSXSlack.)VoidFunctionComponent / (JSXSlack.)VFC', () => {
-      it('accepts only specified props', () => {
-        const voidFunctionalComponent: JSXSlack.VoidFunctionalComponent = () =>
-          null
-        const voidFunctionComponent: JSXSlack.VoidFunctionComponent = () => null
-        const vfc: JSXSlack.VFC<{ test: string }> = ({ test }) => (
-          <JSXSlack.Fragment>{test}</JSXSlack.Fragment>
-        )
-        const publicVoidFunctionComponent: VoidFunctionComponent<{
-          test: string
-        }> = ({ test }) => <JSXSlack.Fragment>{test}</JSXSlack.Fragment>
-        const publicVFC: VFC<Record<string, never>> = () => null
-
-        // @ts-expect-error children prop is not allowed in VoidFunctionalComponent
-        expect(voidFunctionalComponent({ children: [] })).toBeNull()
-        expect(voidFunctionalComponent({})).toBeNull()
-
-        // @ts-expect-error children prop is not allowed in VoidFunctionalComponent
-        expect(voidFunctionComponent({ children: [] })).toBeNull()
-        expect(voidFunctionComponent({})).toBeNull()
-
-        // @ts-expect-error children prop is not allowed in VoidFunctionalComponent
-        expect(vfc({ test: 'abc', children: [] })).toStrictEqual(['abc'])
-        expect(vfc({ test: 'def' })).toStrictEqual(['def'])
-
-        expect(
-          // @ts-expect-error children prop is not allowed in VoidFunctionalComponent
-          publicVoidFunctionComponent({ test: 'abc', children: [] })
-        ).toStrictEqual(['abc'])
-        expect(publicVoidFunctionComponent({ test: 'def' })).toStrictEqual([
-          'def',
-        ])
-
-        // @ts-expect-error children prop is not allowed in VoidFunctionalComponent
-        expect(publicVFC({ children: [] })).toBeNull()
-        expect(publicVFC({})).toBeNull()
+        expect(publicFC({})).toBeNull()
       })
     })
   })

--- a/test/jsx.tsx
+++ b/test/jsx.tsx
@@ -269,7 +269,7 @@ describe('JSX', () => {
         }) => <JSXSlack.Fragment>{test}</JSXSlack.Fragment>
         const publicFC: FC<Record<string, never>> = () => null
 
-        // @ts-expect-error children prop is not allowed in FunctionComponent
+        // // @ts-expect-error children prop is not allowed in FunctionComponent
         expect(functionComponent({ children: [] })).toBeNull()
         expect(functionComponent({})).toBeNull()
 


### PR DESCRIPTION
Match types exported from `JSXSlack` to the update of React 18 type definitions.
https://twitter.com/reactjs/status/1512453230504124420

## Breaking changes

### Removal implicit `children` prop from `FunctionComponent`

The generic type of `JSXSlack.FunctionComponent` for props is no longer included an implicit `children` definition. When using children value(s) in the function component, the developer should make clear definition of children.

![](https://user-images.githubusercontent.com/3993388/162529185-63c0abfd-29ba-41af-924c-c001e8ef2224.png)

A newly exposed `JSXSlack.PropsWithChildren` type would be helpful for adding `children` prop type to the exist props type. [The shape of types is similar to React 18.](https://github.com/eps1lon/types-react-codemod#implicit-children)

```diff
# React 18
-React.FunctionComponent<Props>
+React.FunctionComponent<React.PropsWithChildren<Props>>
-React.FunctionComponent
+React.FunctionComponent<React.PropsWithChildren<unknown>>

# jsx-slack
-JSXSlack.FunctionComponent<Props>
+JSXSlack.FunctionComponent<JSXSlack.PropsWithChildren<Props>>
-JSXSlack.FunctionComponent
+JSXSlack.FunctionComponent<JSXSlack.PropsWithChildren<{}>>
```

## Deprecated types

|Depreacted|Replace to|
|:---:|:---:|
|`VoidFunctionComponent` / `VFC`|`FunctionComponent` / `FC`|
|`FunctionalComponent`|`FunctionComponent` / `FC`|
|`VoidFunctionalComponent`|`FunctionComponent` / `FC`|
|`Props<P>`|`P`|