### PR TITLE
Add `<Video>` layout block support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 
-- [`<Video>` layout block component](./docs/layout-blocks.md#video) ([#272](https://github.com/yhatt/jsx-slack/issues/272), [#273](https://github.com/yhatt/jsx-slack/pull/273))
+- [`<Video>` layout block component](https://github.com/yhatt/jsx-slack/blob/main/docs/layout-blocks.md#video) ([#272](https://github.com/yhatt/jsx-slack/issues/272), [#273](https://github.com/yhatt/jsx-slack/pull/273))
 
 ## v5.0.0 - 2022-06-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- [`<Video>` layout block component](./docs/layout-blocks.md#video) ([#272](https://github.com/yhatt/jsx-slack/issues/272), [#273](https://github.com/yhatt/jsx-slack/pull/273))
+
 ## v5.0.0 - 2022-06-19
 
 ### Breaking

--- a/demo/js/convert.js
+++ b/demo/js/convert.js
@@ -15,15 +15,29 @@ export const convert = (jsx) => {
   const ret = { text: JSON.stringify(output, null, 2) }
 
   if (isValidComponent(output.$$jsxslack.type)) {
-    const { name } = output.$$jsxslack.type.$$jsxslackComponent
+    const container = output.$$jsxslack
+    const { name: containerName } = container.type.$$jsxslackComponent
 
-    if (name === 'Blocks') {
+    const checkVideoBlock = () => {
+      const children = JSXSlack.Children.toArray(container.children)
+      if (
+        children.find(
+          (block) => block.type === 'video' || block.$$jsxslack.type === 'video'
+        )
+      ) {
+        ret.tooltip =
+          'NOTE: The video layout block cannot preview and test in Slack Block Kit Builder.'
+      }
+    }
+
+    if (containerName === 'Blocks') {
       ret.url = generateUrl({ blocks: output })
-    } else if (
-      (name === 'Modal' || name === 'Home') &&
-      (output.type === 'modal' || output.type === 'home')
-    ) {
-      ret.url = generateUrl(output)
+      checkVideoBlock()
+    } else if (containerName === 'Modal' || containerName === 'Home') {
+      if (output.type === 'modal' || output.type === 'home') {
+        ret.url = generateUrl(output)
+        checkVideoBlock()
+      }
     }
   }
 

--- a/demo/js/convert.js
+++ b/demo/js/convert.js
@@ -26,7 +26,7 @@ export const convert = (jsx) => {
         )
       ) {
         ret.tooltip =
-          'NOTE: The video layout block cannot preview and test in Slack Block Kit Builder.'
+          'NOTE: The video layout block may not test and preview in Slack Block Kit Builder.'
       }
     }
 

--- a/demo/js/index.js
+++ b/demo/js/index.js
@@ -82,8 +82,12 @@ const jsxEditor = CodeMirror(jsx, {
   value: initialValue.text,
 })
 
-const setPreview = (url) => {
-  previewBtnContainer.removeAttribute('data-title')
+const setPreview = (url, tooltip) => {
+  if (tooltip) {
+    previewBtnContainer.setAttribute('data-title', tooltip)
+  } else {
+    previewBtnContainer.removeAttribute('data-title')
+  }
 
   if (url) {
     previewBtn.setAttribute('tabindex', 0)
@@ -97,10 +101,10 @@ const setPreview = (url) => {
 
 const process = () => {
   try {
-    const { text, url } = convert(jsxEditor.getValue())
+    const { text, url, tooltip } = convert(jsxEditor.getValue())
 
     json.value = text
-    setPreview(url)
+    setPreview(url, tooltip)
 
     error.classList.add('hide')
   } catch (e) {

--- a/demo/js/schema.js
+++ b/demo/js/schema.js
@@ -23,6 +23,32 @@ const multipleSelectAttrs = {
   multiple: [],
   maxSelectedItems: null,
 }
+const videoCommonAttrs = {
+  titleUrl: null,
+  authorName: null,
+  providerName: null,
+  providerIconUrl: null,
+  description: null,
+}
+const videoIntrinsicAttrs = {
+  src: null,
+  alt: null,
+  title: null,
+  poster: null,
+  id: null,
+  ...videoCommonAttrs,
+}
+const videoComponentAttrs = {
+  src: null,
+  videoUrl: null,
+  alt: null,
+  title: null,
+  poster: null,
+  thumbnailUrl: null,
+  id: null,
+  blockId: null,
+  ...videoCommonAttrs,
+}
 const inputIntrinsicAttrs = {
   label: null,
   title: null,
@@ -67,6 +93,8 @@ const commonKnownBlocks = [
   'Context',
   'Header',
   'header',
+  'Video',
+  'video',
 
   // Input blocks
   'Input',
@@ -159,6 +187,8 @@ const schema = {
   },
   Header: { attrs: blockCommonAttrs, children: ['br'] },
   header: { id: null, children: ['br'] },
+  Video: { attrs: videoComponentAttrs, children: [] },
+  video: { attrs: videoIntrinsicAttrs, children: [] },
   File: {
     attrs: { externalId: null, source: ['remote'], ...blockCommonAttrs },
     children: [],

--- a/docs/jsx-components-for-block-kit.md
+++ b/docs/jsx-components-for-block-kit.md
@@ -18,6 +18,7 @@
 - [**`<Actions>`**: Actions Block](layout-blocks.md#actions)
 - [**`<Context>`**: Context Block](layout-blocks.md#context)
 - [**`<Input>`**: Input Block](layout-blocks.md#input)
+- [**`<Video>`**: Video Block](layout-blocks.md#video)
 - [**`<File>`**: File Block](layout-blocks.md#file) (Only for messaging)
 - [**`<Call>`**: Call Block](layout-blocks.md#call) (Only for messaging)
 

--- a/docs/layout-blocks.md
+++ b/docs/layout-blocks.md
@@ -243,6 +243,45 @@ If you want to use `<Input>` as layout block, you have to place one of [availabl
 
 `<Input>` component for layout block is provided for user that want templating with Slack API style rather than HTML style.
 
+## <a name="video" id="video"></a> [`<Video>`: Video Block](https://api.slack.com/reference/messaging/blocks#video)
+
+A block for embedding a video. The `<video>` intrinsic HTML element works as well.
+
+```jsx
+<Blocks>
+  <Video
+    src="https://www.youtube.com/embed/RRxQQxiM7AA?feature=oembed&autoplay=1"
+    alt="How to use Slack?"
+    title="How to use Slack."
+    poster="https://i.ytimg.com/vi/RRxQQxiM7AA/hqdefault.jpg"
+    authorName="Arcado Buendia"
+    description="Slack is a new way to communicate with your team. It's faster, better organized and more secure than email."
+    titleUrl="https://www.youtube.com/watch?v=RRxQQxiM7AA"
+    providerName="YouTube"
+    providerIconUrl="https://a.slack-edge.com/80588/img/unfurl_icons/youtube.png"
+  />
+</Blocks>
+```
+
+[<img src="./preview-btn.svg" width="240" />](https://jsx-slack.netlify.app/#bkb:jsx:eJx1kk9PAjEQxe98igkHvehWD0ZiWAme9KAJ-CfxZIZ2YKvdztpOWfDTWxaMEOOpTV5m3u-9dnjjWH_E6x7A8MUa4nwBiEGX_UqkiVdKtW1brDlJmlGhuVZUz8io6XQ1mazs_eV4PJoTSgpUcicdYRJuHK7L8363DZ2U_VtuQRhSJHh0qD9GW02sOPqrFlu14SgUflFssRZbLzqMpd1nUNWnoTkmJ8V7s9j5Jqk4PGCdDcZBo2G4SeSNxa1uKOpgG7Hsy35nCzYCgqcWWlxvgLJRnbzVKAStlQpyEQGEsC7gTo4jzHFDeAIzknwChwV6-0UG0BuoORBE0rkbkAo9UI3WFXvJn4P7v-gWRVejZbkXc1dL4GV-q120V05PeeRQutPsD5ZjETcJT8ksttsHZxeDgcptquTnKbg3m0ei-gFofNeiuu4N1e6PfAO2dbnp)
+
+> **Warning** Whether the block can play the embedded video correctly is depending on the Slack app settings and the video URL. Please check out [the requirements and constraints of the video layout block in Slack API documentation](https://api.slack.com/reference/block-kit/blocks#video_requirements) first.
+>
+> Slack Block Kit Builder may not test and preview the video block due to the app constraints. Recommend to use your own Slack app to test.
+
+### Props
+
+- `src` / `videoUrl` (**required**): The URL to be embedded video. _URL must be compatible with an embeddable iframe_ (`<iframe src="******" />`).
+- `alt` (**required**): A tooltip text for the video. It is required by Slack for accessibility.
+- `title` (**required**): A video title (200 characters maximum).
+- `poster` / `thumbnailUrl` (**required**): URL for the thumbnail image of the video.
+- `id` / `blockId` (optional): A string of unique identifier of block.
+- `authorName` (optional): The author name of the video to be displayed (50 characters maximum).
+- `description` (optional): The description for the video.
+- `providerName` (optional): The originating application name or domain of the video. (ex. YouTube)
+- `providerIconUrl` (optional): An image URL for the video provider icon.
+- `titleUrl` (optional): HTTPS URL for the hyperlink of the title text. It must correspond to the non-embeddable URL for the video.
+
 ## <a name="file" id="file"></a> [`<File>`: File Block](https://api.slack.com/reference/messaging/blocks#file) (Only for messaging)
 
 Display a remote file that was added to Slack workspace. [Learn about adding remote files in the document of Slack API.](https://api.slack.com/messaging/files/remote) _This block is only for [`<Blocks>` container](block-containers.md#blocks)._

--- a/package.json
+++ b/package.json
@@ -127,6 +127,6 @@
     "unist-util-visit": "^4.1.0"
   },
   "dependencies": {
-    "@slack/types": "^2.5.0"
+    "@slack/types": "^2.7.0"
   }
 }

--- a/src/block-kit/container/Blocks.ts
+++ b/src/block-kit/container/Blocks.ts
@@ -7,6 +7,7 @@ import { Header } from '../layout/Header'
 import { Image } from '../layout/Image'
 import { Input, knownInputs } from '../layout/Input'
 import { availableSectionAccessoryTypes, Section } from '../layout/Section'
+import { Video } from '../layout/Video'
 import {
   BlocksProps,
   generateActionsValidator,
@@ -27,6 +28,7 @@ import {
  * - `<Context>`
  * - `<Actions>`
  * - `<Input>` (`<input>`)
+ * - `<Video>` (`<video>`)
  * - `<File>`
  * - `<Call>`
  *
@@ -74,6 +76,7 @@ export const Blocks: BuiltInComponent<BlocksProps> = generateBlocksContainer({
     image: true,
     input: true,
     section: generateSectionValidator(availableSectionAccessoryTypes),
+    video: true,
   },
   aliases: {
     header: Header,
@@ -83,6 +86,7 @@ export const Blocks: BuiltInComponent<BlocksProps> = generateBlocksContainer({
     section: Section,
     select: Select,
     textarea: Textarea,
+    video: Video,
   },
   typesToCheckMissingLabel: knownInputs,
 })

--- a/src/block-kit/container/Home.tsx
+++ b/src/block-kit/container/Home.tsx
@@ -13,6 +13,7 @@ import { Header } from '../layout/Header'
 import { Image } from '../layout/Image'
 import { Input, knownInputs } from '../layout/Input'
 import { Section } from '../layout/Section'
+import { Video } from '../layout/Video'
 import {
   PrivateMetadataTransformer,
   generateActionsValidator,
@@ -74,6 +75,7 @@ const HomeBlocks = generateBlocksContainer({
     image: true,
     input: true,
     section: generateSectionValidator(),
+    video: true,
   },
   aliases: {
     header: Header,
@@ -83,6 +85,7 @@ const HomeBlocks = generateBlocksContainer({
     section: Section,
     select: Select,
     textarea: Textarea,
+    video: Video,
   },
   typesToCheckMissingLabel: knownInputs,
 })
@@ -100,6 +103,7 @@ const HomeBlocks = generateBlocksContainer({
  * - `<Context>`
  * - `<Actions>`
  * - `<Input>` (`<input>`)
+ * - `<Video>` (`<video>`)
  *
  * And these input components (Require defining `label` prop):
  *

--- a/src/block-kit/container/Modal.tsx
+++ b/src/block-kit/container/Modal.tsx
@@ -15,6 +15,7 @@ import { Header } from '../layout/Header'
 import { Image } from '../layout/Image'
 import { Input, knownInputs } from '../layout/Input'
 import { Section } from '../layout/Section'
+import { Video } from '../layout/Video'
 import {
   PrivateMetadataTransformer,
   generateActionsValidator,
@@ -130,6 +131,7 @@ const ModalBlocks = generateBlocksContainer({
     image: true,
     input: true,
     section: generateSectionValidator(),
+    video: true,
   },
   aliases: {
     header: Header,
@@ -139,6 +141,7 @@ const ModalBlocks = generateBlocksContainer({
     section: Section,
     select: Select,
     textarea: Textarea,
+    video: Video,
   },
   typesToCheckMissingLabel: knownInputs,
 })
@@ -158,6 +161,7 @@ const commonDefaultSubmit = plainText('Submit')
  * - `<Context>`
  * - `<Actions>`
  * - `<Input>` (`<input>`)
+ * - `<Video>` (`<video>`)
  *
  * And these input components (Require defining `label` prop):
  *

--- a/src/block-kit/index.ts
+++ b/src/block-kit/index.ts
@@ -13,6 +13,7 @@ export { Header } from './layout/Header'
 export { Image } from './layout/Image'
 export { Input } from './layout/Input'
 export { Section, Field } from './layout/Section'
+export { Video } from './layout/Video'
 
 // Block elements
 export { Button } from './elements/Button'

--- a/src/block-kit/layout/Input.tsx
+++ b/src/block-kit/layout/Input.tsx
@@ -1,5 +1,5 @@
 /** @jsx createElementInternal */
-import { InputBlock as _InputBlock } from '@slack/types'
+import { InputBlock } from '@slack/types'
 import { JSXSlackError } from '../../error'
 import { JSXSlack } from '../../jsx'
 import {
@@ -22,8 +22,6 @@ import {
 } from '../elements/utils'
 import { resolveTagName } from '../utils'
 import { LayoutBlockProps } from './utils'
-
-type InputBlock = _InputBlock & { dispatch_action?: boolean }
 
 interface InputLayoutProps extends LayoutBlockProps {
   children: JSXSlack.Node

--- a/src/block-kit/layout/Video.ts
+++ b/src/block-kit/layout/Video.ts
@@ -1,0 +1,104 @@
+// import { VideoBlock } from '@slack/types'
+import { Block, PlainTextElement } from '@slack/types'
+import { createComponent } from '../../jsx-internals'
+import { plainText } from '../composition/utils'
+import { LayoutBlockProps } from './utils'
+
+// TODO: https://github.com/slackapi/node-slack-sdk/pull/1514 has been merged into @slack/types but it hasn't been released yet.
+interface VideoBlock extends Block {
+  type: 'video'
+  video_url: string
+  thumbnail_url: string
+  alt_text: string
+  title: PlainTextElement
+  title_url?: string
+  author_name?: string
+  provider_name?: string
+  provider_icon_url?: string
+  description?: PlainTextElement
+}
+
+interface VideoPropsInternal extends LayoutBlockProps {
+  children?: never
+
+  /**
+   * The URL to be embedded video.
+   *
+   * _URL must be compatible with an embeddable iframe._
+   *
+   * In addition, it has a lot of requirements by Slack for putting video
+   * correctly. [See also requirements for `video_url` field in Slack API documentation.](https://api.slack.com/reference/block-kit/blocks#video_requirements)
+   */
+  videoUrl?: string
+
+  /** An alias to `videoUrl` prop. */
+  src?: string
+
+  /** A tooltip text for the video. It is required for accessibility. */
+  alt: string
+
+  /** URL for the thumbnail image of the video. */
+  thumbnailUrl?: string
+
+  /** An alias to `thumbnailUrl` prop. */
+  poster?: string
+
+  /** A video title, in 200 or less characters. */
+  title: string
+
+  /**
+   * HTTPS URL for the hyperlink of the title text.
+   *
+   * It must correspond to the non-embeddable URL for the video.
+   */
+  titleUrl?: string
+
+  /** The author name of the video to be displayed, in 50 or less characters. */
+  authorName?: string
+
+  /** The originating application name or domain of the video. (ex. YouTube) */
+  providerName?: string
+
+  /** An image URL for the video provider icon. */
+  providerIconUrl?: string
+
+  /** Description for the video. */
+  description?: string
+}
+
+type SelectiveRequired<T, K extends keyof T> = T & Required<Pick<T, K>>
+type RequiredOneOf<T, K extends keyof T> = K extends never
+  ? never
+  : SelectiveRequired<T, K>
+
+export type VideoProps = RequiredOneOf<
+  RequiredOneOf<VideoPropsInternal, 'src' | 'videoUrl'>,
+  'poster' | 'thumbnailUrl'
+>
+
+/**
+ * [The `video` layout block](https://api.slack.com/reference/messaging/blocks#video)
+ * to embed a video.
+ *
+ * Recommend to learn about [requirements and constraints](https://api.slack.com/reference/block-kit/blocks#video_requirements)
+ * of the video layout block in Slack API documentation.
+ *
+ * @return The partial JSON for `video` layout block
+ */
+export const Video = createComponent<VideoProps, VideoBlock>(
+  'Video',
+  (props) => ({
+    type: 'video',
+    block_id: props.blockId || props.id,
+    video_url: (props.videoUrl || props.src) as string,
+    alt_text: props.alt,
+    thumbnail_url: (props.thumbnailUrl || props.poster) as string,
+    title: plainText(props.title),
+    title_url: props.titleUrl,
+    author_name: props.authorName,
+    provider_name: props.providerName,
+    provider_icon_url: props.providerIconUrl,
+    description:
+      props.description != null ? plainText(props.description) : undefined,
+  })
+)

--- a/src/jsx.ts
+++ b/src/jsx.ts
@@ -10,6 +10,7 @@ import { HeaderProps } from './block-kit/layout/Header'
 import { ImageProps } from './block-kit/layout/Image'
 import { InputProps } from './block-kit/layout/Input'
 import { SectionProps } from './block-kit/layout/Section'
+import { VideoProps } from './block-kit/layout/Video'
 import {
   FragmentInternal,
   createElementInternal,
@@ -335,6 +336,9 @@ export namespace JSXSlack {
        * component.
        */
       select: SelectProps & AutoFocusibleIntrinsicProps
+
+      /** A HTML-compatible alias into `<Video>` layout block. */
+      video: VideoProps
 
       // ----------- HTML-like elements -----------
 

--- a/test/block-kit/layout-blocks.tsx
+++ b/test/block-kit/layout-blocks.tsx
@@ -33,6 +33,7 @@ import {
   Select,
   TimePicker,
   UsersSelect,
+  Video,
 } from '../../src/index'
 
 beforeEach(() => JSXSlack.exactMode(false))
@@ -528,6 +529,95 @@ describe('Layout blocks', () => {
           A<p>B</p>C
         </Header>
       ).toHaveProperty('text.text', 'A\n\nB\n\nC')
+    })
+  })
+
+  describe('<Video>', () => {
+    const video = {
+      alt_text: 'Video example',
+      author_name: 'author',
+      block_id: 'video',
+      description: { type: 'plain_text', text: 'Description', emoji: true },
+      provider_icon_url: 'https://example.com/favicon.png',
+      provider_name: 'Example site',
+      thumbnail_url: 'https://example.com/video/thumbnail.jpg',
+      title_url: 'https://example.com/video/',
+      title: { type: 'plain_text', text: 'Video example', emoji: true },
+      type: 'video',
+      video_url: 'https://example.com/video/embed',
+    }
+
+    it('outpus video block', () => {
+      // Full
+      expect(
+        <Blocks>
+          <Video
+            videoUrl="https://example.com/video/embed"
+            alt="Video example"
+            title="Video example"
+            thumbnailUrl="https://example.com/video/thumbnail.jpg"
+            blockId="video"
+            authorName="author"
+            description="Description"
+            providerName="Example site"
+            providerIconUrl="https://example.com/favicon.png"
+            titleUrl="https://example.com/video/"
+          />
+        </Blocks>
+      ).toStrictEqual([video])
+
+      // Minimum
+      expect(
+        <Blocks>
+          <Video
+            // Test alias props for HTML compatibillity
+            src="https://example.com/video/embed"
+            alt="Video example"
+            title="Video example"
+            poster="https://example.com/video/thumbnail.jpg"
+          />
+        </Blocks>
+      ).toStrictEqual([
+        {
+          type: 'video',
+          video_url: 'https://example.com/video/embed',
+          alt_text: 'Video example',
+          title: { type: 'plain_text', text: 'Video example', emoji: true },
+          thumbnail_url: 'https://example.com/video/thumbnail.jpg',
+        },
+      ])
+    })
+
+    it('is aliased from <video> HTML intrinsic element by container', () => {
+      const videoIntrinsicElement = (
+        <video
+          // Prefers Slack API field props over HTML-compatible alias props
+          blockId="video" // <=
+          id="id"
+          poster="https://example.com/video/poster.jpg"
+          src="https://example.com/video/src"
+          thumbnailUrl="https://example.com/video/thumbnail.jpg" // <=
+          videoUrl="https://example.com/video/embed" // <=
+          // optionals
+          alt="Video example"
+          title="Video example"
+          authorName="author"
+          description="Description"
+          providerName="Example site"
+          providerIconUrl="https://example.com/favicon.png"
+          titleUrl="https://example.com/video/"
+        />
+      )
+
+      expect(<Blocks>{videoIntrinsicElement}</Blocks>).toStrictEqual([video])
+
+      expect(
+        <Modal title="modal">{videoIntrinsicElement}</Modal>
+      ).toHaveProperty('blocks', [video])
+
+      expect(<Home>{videoIntrinsicElement}</Home>).toHaveProperty('blocks', [
+        video,
+      ])
     })
   })
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1366,10 +1366,10 @@
   dependencies:
     "@sinonjs/commons" "^1.7.0"
 
-"@slack/types@^2.5.0":
-  version "2.5.0"
-  resolved "https://registry.yarnpkg.com/@slack/types/-/types-2.5.0.tgz#105a0ca39fa26c1f6f822887d0de553737555d07"
-  integrity sha512-EXS+D5BWmArY2rW4V8om/y5rwnjPxlXJP1SlRsStF/rQJWWBQDwOnzuS7km2O19GA07sY7T1lIe/iy6YzTf4GQ==
+"@slack/types@^2.7.0":
+  version "2.7.0"
+  resolved "https://registry.yarnpkg.com/@slack/types/-/types-2.7.0.tgz#54459d92866b9255880a62a47f03fa76d23af40f"
+  integrity sha512-QUrHBilZeWyXAuHfEbSnzBwvFm4u/75LHKRKu8xRUnGNt35Amz8y9YQwb6voU1S5FmTYxMNAL+ZbAPTor4aRdw==
 
 "@trysound/sax@0.2.0":
   version "0.2.0"


### PR DESCRIPTION
```jsx
<Blocks>
  <Video
    src="https://www.youtube.com/embed/RRxQQxiM7AA?feature=oembed&autoplay=1"
    alt="How to use Slack?"
    title="How to use Slack."
    poster="https://i.ytimg.com/vi/RRxQQxiM7AA/hqdefault.jpg"
    authorName="Arcado Buendia"
    description="Slack is a new way to communicate with your team. It's faster, better organized and more secure than email."
    titleUrl="https://www.youtube.com/watch?v=RRxQQxiM7AA"
    providerName="YouTube"
    providerIconUrl="https://a.slack-edge.com/80588/img/unfurl_icons/youtube.png"
  />
</Blocks>
```

Resolves #272.

### ToDo

- [x] Implementations
  - [x] `<Video>` component for the video layout block
  - [x] `<video>` intrinsic HTML element alias for Block Kit surfaces
- [x] Test against `<Video>` and `<video>`
- [x] Update references
- [x] Update demo
  - [x] Auto-complete for `<Video>` component / `<video>` element in demo page
  - [x] Tool-tip to warn about [incompatibility of the video layout block with Slack Block Kit Builder](https://api.slack.com/reference/block-kit/blocks#video:~:text=Video%20blocks%20can%20only%20be%20posted%20by%20apps%3B%20users%20are%20not%20allowed%20to%20post%20embedded%20videos%20directly%20from%20Block%20Kit%20Builder.)