### PR TITLE
Make stable documentation anchor links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - [`<Video>` layout block component](https://github.com/yhatt/jsx-slack/blob/main/docs/layout-blocks.md#user-content-video) ([#272](https://github.com/yhatt/jsx-slack/issues/272), [#273](https://github.com/yhatt/jsx-slack/pull/273))
 
+### Fixed
+
+- Make stable documentation anchor links ([#274](https://github.com/yhatt/jsx-slack/pull/274))
+
 ## v5.0.0 - 2022-06-19
 
 ### Breaking

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 
-- [`<Video>` layout block component](https://github.com/yhatt/jsx-slack/blob/main/docs/layout-blocks.md#video) ([#272](https://github.com/yhatt/jsx-slack/issues/272), [#273](https://github.com/yhatt/jsx-slack/pull/273))
+- [`<Video>` layout block component](https://github.com/yhatt/jsx-slack/blob/main/docs/layout-blocks.md#user-content-video) ([#272](https://github.com/yhatt/jsx-slack/issues/272), [#273](https://github.com/yhatt/jsx-slack/pull/273))
 
 ## v5.0.0 - 2022-06-19
 
@@ -204,8 +204,8 @@ The package name has renamed from `@speee-js/jsx-slack` to `jsx-slack`.
 
 ### Added
 
-- [Configurable `dispatchAction` prop](https://github.com/yhatt/jsx-slack/blob/main/docs/block-elements.md#input) for `<Input type="text">` and `<Textarea>` (equivalent to [`dispatch_action_config` for the plain-text input](https://api.slack.com/reference/block-kit/block-elements#input)) ([#204](https://github.com/yhatt/jsx-slack/issues/204), [#205](https://github.com/yhatt/jsx-slack/pull/205))
-- [`<Mrkdwn raw>`](https://github.com/yhatt/jsx-slack/blob/main/docs/block-elements.md#bypass-html-like-formatting) to bypass HTML-like formatting and auto-escaping ([#161](https://github.com/yhatt/jsx-slack/issues/161), [#207](https://github.com/yhatt/jsx-slack/pull/207))
+- [Configurable `dispatchAction` prop](https://github.com/yhatt/jsx-slack/blob/main/docs/block-elements.md#user-content-input) for `<Input type="text">` and `<Textarea>` (equivalent to [`dispatch_action_config` for the plain-text input](https://api.slack.com/reference/block-kit/block-elements#input)) ([#204](https://github.com/yhatt/jsx-slack/issues/204), [#205](https://github.com/yhatt/jsx-slack/pull/205))
+- [`<Mrkdwn raw>`](https://github.com/yhatt/jsx-slack/blob/main/docs/block-elements.md#user-content-bypass-html-like-formatting) to bypass HTML-like formatting and auto-escaping ([#161](https://github.com/yhatt/jsx-slack/issues/161), [#207](https://github.com/yhatt/jsx-slack/pull/207))
 
 ### Fixed
 
@@ -219,7 +219,7 @@ The package name has renamed from `@speee-js/jsx-slack` to `jsx-slack`.
 
 ### Added
 
-- [`<TimePicker>` interactive component](https://github.com/yhatt/jsx-slack/blob/main/docs/block-elements.md#time-picker) ([#199](https://github.com/yhatt/jsx-slack/issues/199), [#202](https://github.com/yhatt/jsx-slack/pull/202))
+- [`<TimePicker>` interactive component](https://github.com/yhatt/jsx-slack/blob/main/docs/block-elements.md#user-content-time-picker) ([#199](https://github.com/yhatt/jsx-slack/issues/199), [#202](https://github.com/yhatt/jsx-slack/pull/202))
 
 ### Fixed
 
@@ -236,13 +236,13 @@ The package name has renamed from `@speee-js/jsx-slack` to `jsx-slack`.
 ### Added
 
 - `dispatchAction` prop for `<Input>` layout block and input components ([#200](https://github.com/yhatt/jsx-slack/pull/200))
-- Docs: [`jsxFragmentFactory` compiler option for TypeScript v4](https://github.com/yhatt/jsx-slack/blob/main/docs/how-to-setup-jsx-transpiler.md#typescript) ([#173](https://github.com/yhatt/jsx-slack/issues/173), [#191](https://github.com/yhatt/jsx-slack/pull/191))
+- Docs: [`jsxFragmentFactory` compiler option for TypeScript v4](https://github.com/yhatt/jsx-slack/blob/main/docs/how-to-setup-jsx-transpiler.md#user-content-typescript) ([#173](https://github.com/yhatt/jsx-slack/issues/173), [#191](https://github.com/yhatt/jsx-slack/pull/191))
 
 ## v2.4.0 - 2020-07-30
 
 ### Added
 
-- [`<Header>` component](https://github.com/yhatt/jsx-slack/blob/main/docs/layout-blocks.md#header) for layout block ([#184](https://github.com/yhatt/jsx-slack/issues/184), [#185](https://github.com/yhatt/jsx-slack/pull/185))
+- [`<Header>` component](https://github.com/yhatt/jsx-slack/blob/main/docs/layout-blocks.md#user-content-header) for layout block ([#184](https://github.com/yhatt/jsx-slack/issues/184), [#185](https://github.com/yhatt/jsx-slack/pull/185))
 
 ### Fixed
 
@@ -276,7 +276,7 @@ The package name has renamed from `@speee-js/jsx-slack` to `jsx-slack`.
 
 ### Added
 
-- [`<Call>` layout block component](https://github.com/yhatt/jsx-slack/blob/main/docs/layout-blocks.md#call) to show a card of registered call ([#164](https://github.com/yhatt/jsx-slack/issues/164), [#165](https://github.com/yhatt/jsx-slack/pull/165))
+- [`<Call>` layout block component](https://github.com/yhatt/jsx-slack/blob/main/docs/layout-blocks.md#user-content-call) to show a card of registered call ([#164](https://github.com/yhatt/jsx-slack/issues/164), [#165](https://github.com/yhatt/jsx-slack/pull/165))
 
 ### Changed
 
@@ -286,7 +286,7 @@ The package name has renamed from `@speee-js/jsx-slack` to `jsx-slack`.
 
 ### Added
 
-- Accept [special initial conversation `current`](https://github.com/yhatt/jsx-slack/blob/main/docs/block-elements.md#special-initial-conversation-current) in `<ConversationsSelect>` ([#154](https://github.com/yhatt/jsx-slack/issues/154), [#155](https://github.com/yhatt/jsx-slack/pull/155))
+- Accept [special initial conversation `current`](https://github.com/yhatt/jsx-slack/blob/main/docs/block-elements.md#user-content-special-initial-conversation-current) in `<ConversationsSelect>` ([#154](https://github.com/yhatt/jsx-slack/issues/154), [#155](https://github.com/yhatt/jsx-slack/pull/155))
 
 ### Changed
 
@@ -307,11 +307,11 @@ jsx-slack v2 has improved JSX structure and built-in components to output the _r
 
 **[▶︎ See highlight of v2 updates](https://github.com/yhatt/jsx-slack/blob/main/docs/highlight/v2.md)**
 
-### [Breaking](https://github.com/yhatt/jsx-slack/blob/main/docs/highlight/v2.md#breaking-change)
+### [Breaking](https://github.com/yhatt/jsx-slack/blob/main/docs/highlight/v2.md#user-content-breaking-change)
 
 - Checked states defined in `<CheckboxGroup values>` and `<Checkbox checked>` do no longer merge
 
-* [Breaking for TypeScript](https://github.com/yhatt/jsx-slack/blob/main/docs/highlight/v2.md#changes-for-TypeScript)
+* [Breaking for TypeScript](https://github.com/yhatt/jsx-slack/blob/main/docs/highlight/v2.md#user-content-changes-for-TypeScript)
   - Require TypeScript >= 3.7 when using jsx-slack through TypeScript
   - Container components have strict type checking for its children
   - Exported type `JSXSlack.Child` and `JSXSlack.Children` have been renamed into `JSXSlack.ChildElement` and `JSXSlack.ChildElements` and no longer provided generics
@@ -430,18 +430,18 @@ jsx-slack v2 has improved JSX structure and built-in components to output the _r
 
 ### Changed
 
-- [Fully-rewrite HTML parser](https://github.com/yhatt/jsx-slack/blob/main/docs/html-like-formatting.md#about-parser) to reduce bundle size drastically (x43 smaller) ([#112](https://github.com/yhatt/jsx-slack/pull/112))
+- [Fully-rewrite HTML parser](https://github.com/yhatt/jsx-slack/blob/main/docs/html-like-formatting.md#user-content-about-parser) to reduce bundle size drastically (x43 smaller) ([#112](https://github.com/yhatt/jsx-slack/pull/112))
 
 ### Added
 
-- [`legacyParser()`](https://github.com/yhatt/jsx-slack/blob/main/docs/html-like-formatting.md#legacy-parser) for switching into legacy parser ([#112](https://github.com/yhatt/jsx-slack/pull/112))
+- [`legacyParser()`](https://github.com/yhatt/jsx-slack/blob/main/docs/html-like-formatting.md#user-content-legacy-parser) for switching into legacy parser ([#112](https://github.com/yhatt/jsx-slack/pull/112))
 
 ## v1.2.0 - 2020-02-10
 
 ### Added
 
-- [`<CheckboxGroup>`](https://github.com/yhatt/jsx-slack/blob/main/docs/block-elements.md#checkbox-group) and [`<Checkbox>`](https://github.com/yhatt/jsx-slack/blob/main/docs/block-elements.md#checkbox) interactive component ([#108](https://github.com/yhatt/jsx-slack/issues/108), [#109](https://github.com/yhatt/jsx-slack/pull/109))
-- [Redirect the content of `<small>` element into `description`](https://github.com/yhatt/jsx-slack/blob/main/docs/block-elements.md#redirect-small-into-description) in `<Checkbox>` and `<RadioButton>` ([#109](https://github.com/yhatt/jsx-slack/pull/109))
+- [`<CheckboxGroup>`](https://github.com/yhatt/jsx-slack/blob/main/docs/block-elements.md#user-content-checkbox-group) and [`<Checkbox>`](https://github.com/yhatt/jsx-slack/blob/main/docs/block-elements.md#user-content-checkbox) interactive component ([#108](https://github.com/yhatt/jsx-slack/issues/108), [#109](https://github.com/yhatt/jsx-slack/pull/109))
+- [Redirect the content of `<small>` element into `description`](https://github.com/yhatt/jsx-slack/blob/main/docs/block-elements.md#user-content-redirect-small-into-description) in `<Checkbox>` and `<RadioButton>` ([#109](https://github.com/yhatt/jsx-slack/pull/109))
 - Add the build for ES modules to make tree-shakable ([#110](https://github.com/yhatt/jsx-slack/pull/110))
 
 ### Changed
@@ -453,7 +453,7 @@ jsx-slack v2 has improved JSX structure and built-in components to output the _r
 
 ### Added
 
-- [Custom transformer](https://github.com/yhatt/jsx-slack/blob/main/docs/block-elements.md#custom-transformer) for modal's private metadata ([#106](https://github.com/yhatt/jsx-slack/pull/106))
+- [Custom transformer](https://github.com/yhatt/jsx-slack/blob/main/docs/block-elements.md#user-content-custom-transformer) for modal's private metadata ([#106](https://github.com/yhatt/jsx-slack/pull/106))
 
 ### Changed
 
@@ -512,7 +512,7 @@ jsx-slack v2 has improved JSX structure and built-in components to output the _r
 ### Added
 
 - Add (an experimental) `<Home>` container component for home tab ([#75](https://github.com/yhatt/jsx-slack/issues/75), [#78](https://github.com/yhatt/jsx-slack/pull/78))
-- [`<RadioButtonGroup>`](https://github.com/yhatt/jsx-slack/blob/main/docs/block-elements.md#radio-button-group) and [`<RadioButton>`](https://github.com/yhatt/jsx-slack/blob/main/docs/block-elements.md#radio-button) interactive component for home tab ([#74](https://github.com/yhatt/jsx-slack/issues/74), [#80](https://github.com/yhatt/jsx-slack/pull/80))
+- [`<RadioButtonGroup>`](https://github.com/yhatt/jsx-slack/blob/main/docs/block-elements.md#user-content-radio-button-group) and [`<RadioButton>`](https://github.com/yhatt/jsx-slack/blob/main/docs/block-elements.md#user-content-radio-button) interactive component for home tab ([#74](https://github.com/yhatt/jsx-slack/issues/74), [#80](https://github.com/yhatt/jsx-slack/pull/80))
 - "Copy to clipboard" button on REPL demo ([#77](https://github.com/yhatt/jsx-slack/pull/77))
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -259,9 +259,9 @@ By using jsx-slack, you can build a template with piling up Block Kit blocks by 
   - [Block containers](docs/block-containers.md)
   - [Layout blocks](docs/layout-blocks.md)
   - [Block elements](docs/block-elements.md)
-    - [Interactive components](docs/block-elements.md#interactive-components)
-    - [Composition objects](docs/block-elements.md#composition-objects)
-    - [Input components](docs/block-elements.md#input-components)
+    - [Interactive components](docs/block-elements.md#user-content-interactive-components)
+    - [Composition objects](docs/block-elements.md#user-content-composition-objects)
+    - [Input components](docs/block-elements.md#user-content-input-components)
 
 * **[HTML-like formatting](docs/html-like-formatting.md)**
 * **[About escape and exact mode](docs/about-escape-and-exact-mode.md)**

--- a/docs/about-escape-and-exact-mode.md
+++ b/docs/about-escape-and-exact-mode.md
@@ -10,7 +10,7 @@ We think that anyone never wants to care about special characters for Slack mrkd
 
 The content may break when JSX contents may have mrkdwn special characters like `*`, `_`, `~`, `` ` ``, and `>`.
 
-### <a name="escape" id="escape"></a> `<Escape>`: Escape special characters
+### <a name="user-content-escape" id="escape"></a> `<Escape>`: Escape special characters
 
 To battle against breaking message, we provide `<Escape>` component to keep special characters as plain text as possible (or replace into another similar character on the part of some restricted).
 

--- a/docs/block-containers.md
+++ b/docs/block-containers.md
@@ -4,7 +4,7 @@
 
 [Slack provides multiple surfaces](https://api.slack.com/surfaces) to place Block Kit [layout blocks](layout-blocks.md). So you should choose the parent container component depending on purpose.
 
-## <a name="blocks" id="blocks"></a> [`<Blocks>`: The basic container for messages](https://api.slack.com/surfaces/messages)
+## <a name="user-content-blocks" id="blocks"></a> [`<Blocks>`: The basic container for messages](https://api.slack.com/surfaces/messages)
 
 A basic container component for Block Kit suited to [messages](https://api.slack.com/surfaces/messages). Wrap layout block components in `<Blocks>`.
 
@@ -26,7 +26,7 @@ api.chat.postMessage({
 })
 ```
 
-## <a name="modal" id="modal"></a> [`<Modal>`: The view container for modals](https://api.slack.com/surfaces/modals)
+## <a name="user-content-modal" id="modal"></a> [`<Modal>`: The view container for modals](https://api.slack.com/surfaces/modals)
 
 The container component for [modals](https://api.slack.com/block-kit/surfaces/modals). You can build view payload for modal through JSX.
 
@@ -90,7 +90,7 @@ export const shareModal = (opts) => (
 
 - `submit` (optional): By setting as `false`, the submit button will be disabled _until one or more inputs have filled_. It is corresponding with [`submit_disabled` field in a configuration view object](https://api.slack.com/reference/workflows/configuration-view).
 
-## <a name="home" id="home"></a> [`<Home>`: The view container for home tabs](https://api.slack.com/surfaces/tabs)
+## <a name="user-content-home" id="home"></a> [`<Home>`: The view container for home tabs](https://api.slack.com/surfaces/tabs)
 
 The container component for [home tabs](https://api.slack.com/surfaces/tabs). You can build view payload for home tab.
 

--- a/docs/block-containers.md
+++ b/docs/block-containers.md
@@ -44,7 +44,7 @@ api.views.open({
 })
 ```
 
-In addition to [layout blocks](layout-blocks.md), `<Modal>` container can place [input components](block-elements.md#input-components) as the children directly. So you can compose blocks for modal with predictable JSX template inspired from HTML form.
+In addition to [layout blocks](layout-blocks.md), `<Modal>` container can place [input components](block-elements.md#user-content-input-components) as the children directly. So you can compose blocks for modal with predictable JSX template inspired from HTML form.
 
 ```jsx
 /** @jsx JSXSlack.h */
@@ -72,14 +72,14 @@ export const shareModal = (opts) => (
   - [`modal`](https://api.slack.com/reference/surfaces/views) _(default)_: The regular modal surface.
   - [`workflow_step`](https://api.slack.com/reference/workflows/configuration-view): The modal surface for [custom workflow step](https://api.slack.com/workflows/steps).
 
-* `privateMetadata` (optional): An optional string that can be found in payloads of some interactive events Slack app received (3000 characters maximum). [By setting function, you can use the custom transformer to serialize hidden values set up via `<Input type="hidden">`](block-elements.md#custom-transformer).
+* `privateMetadata` (optional): An optional string that can be found in payloads of some interactive events Slack app received (3000 characters maximum). [By setting function, you can use the custom transformer to serialize hidden values set up via `<Input type="hidden">`](block-elements.md#user-content-custom-transformer).
 * `callbackId` (optional): An identifier for this modal to recognize it in various events. (255 characters maximum)
 
 #### Props for `modal` type
 
 - `title` (**required**): An user-facing title of the modal. (24 characters maximum)
 - `close` (optional): A text for close button of the modal. (24 characters maximum)
-- `submit` (optional): A text for submit button of the modal. The value specified in this prop is preferred than [`<Input type="submit">`](block-elements.md#input-submit) (24 characters maximum)
+- `submit` (optional): A text for submit button of the modal. The value specified in this prop is preferred than [`<Input type="submit">`](block-elements.md#user-content-input-submit) (24 characters maximum)
 - `clearOnClose` (optional): If enabled by setting `true`, all stacked views will be cleared by close button.
 - `notifyOnClose` (optional): If enabled by setting `true`, `view_closed` event will be sent to request URL of Slack app when closed modal.
 - `externalId` (optional): A unique ID for all views on a per-team basis.
@@ -109,11 +109,11 @@ api.views.publish({
 
 [<img src="./preview-btn.svg" width="240" />](https://jsx-slack.netlify.app/#bkb:jsx:eJyz8cjPTbXjUlCwCU5NLsnMz7MLT81JBooplOQr5FYqZACZijb6MEkuG32wBgD3vRIW)
 
-As same as `<Modal>`, `<Home>` can place [input components](block-elements.md#input-components) as the direct child.
+As same as `<Modal>`, `<Home>` can place [input components](block-elements.md#user-content-input-components) as the direct child.
 
 ### Props
 
-- `privateMetadata` (optional): An optional string that can be found in payloads of some interactive events Slack app received. (3000 characters maximum) [By setting function, you can use the custom transformer to serialize hidden values set up via `<Input type="hidden">`](block-elements.md#custom-transformer).
+- `privateMetadata` (optional): An optional string that can be found in payloads of some interactive events Slack app received. (3000 characters maximum) [By setting function, you can use the custom transformer to serialize hidden values set up via `<Input type="hidden">`](block-elements.md#user-content-custom-transformer).
 - `callbackId` (optional): An identifier for this modal to recognize it in various events. (255 characters maximum)
 - `externalId` (optional): A unique ID for all views on a per-team basis.
 

--- a/docs/block-elements.md
+++ b/docs/block-elements.md
@@ -6,7 +6,7 @@ Slack provides some **[block elements](https://api.slack.com/reference/block-kit
 
 ## Interactive components
 
-### <a name="button" id="button"></a> [`<Button>`: Button element](https://api.slack.com/reference/messaging/block-elements#button)
+### <a name="user-content-button" id="button"></a> [`<Button>`: Button element](https://api.slack.com/reference/messaging/block-elements#button)
 
 A simple button to send action to registered Slack App, or open external URL. `<button>` intrinsic HTML element also works as well.
 
@@ -37,7 +37,7 @@ A simple button to send action to registered Slack App, or open external URL. `<
 
 [confirmation dialog object]: https://api.slack.com/reference/block-kit/composition-objects#confirm
 
-### <a name="select" id="select"></a> [`<Select>`: Select menu with static options](https://api.slack.com/reference/messaging/block-elements#static_select)
+### <a name="user-content-select" id="select"></a> [`<Select>`: Select menu with static options](https://api.slack.com/reference/messaging/block-elements#static_select)
 
 A menu element with static options passed by `<Option>` or `<Optgroup>`. It has a interface similar to `<select>` HTML element. In fact, `<select>` intrinsic HTML element works as well.
 
@@ -147,7 +147,7 @@ The above JSX means exactly same as following usage of [`<Input>` layout block](
 - `required` (optional): A boolean prop to specify whether any value must be filled when user confirms modal.
 - `dispatchAction` (optional): By setting `true`, the input element will dispatch [`block_actions` payload](https://api.slack.com/reference/interaction-payloads/block-actions) when used this.
 
-### <a name="option" id="option"></a> `<Option>`: Menu item
+### <a name="user-content-option" id="option"></a> `<Option>`: Menu item
 
 Define an item for `<Select>`. `<option>` intrinsic HTML element works as well.
 
@@ -156,7 +156,7 @@ Define an item for `<Select>`. `<option>` intrinsic HTML element works as well.
 - `value` (optional): A string value to send to Slack App when choose item. Use its content string as value if omitted.
 - `selected` (optional): A boolean value to indicate initially selected option(s). _It will work only when the parent `<Select>` did not define `value` prop._
 
-### <a name="optgroup" id="optgroup"></a> `<Optgroup>`: Group of menu items
+### <a name="user-content-optgroup" id="optgroup"></a> `<Optgroup>`: Group of menu items
 
 Define a group for `<Select>`. `<optgroup>` intrinsic HTML element works as well.
 
@@ -184,7 +184,7 @@ Define a group for `<Select>`. `<optgroup>` intrinsic HTML element works as well
 
 - `label` (**required**): A plain text to be shown as a group name.
 
-### <a name="external-select" id="external-select"></a> [`<ExternalSelect>`: Select menu with external data source](https://api.slack.com/reference/messaging/block-elements#external_select)
+### <a name="user-content-external-select" id="external-select"></a> [`<ExternalSelect>`: Select menu with external data source](https://api.slack.com/reference/messaging/block-elements#external_select)
 
 You should use `<ExternalSelect>` if you want to provide the dynamic list from external source.
 
@@ -226,7 +226,7 @@ It requires setup JSON entry URL in your Slack app. [Learn about external source
 - `required` (optional): A boolean prop to specify whether any value must be filled when user confirms modal.
 - `dispatchAction` (optional): By setting `true`, the input element will dispatch [`block_actions` payload](https://api.slack.com/reference/interaction-payloads/block-actions) when used this.
 
-### <a name="select-fragment" id="select-fragment"></a> `<SelectFragment>`: Generate options for external source
+### <a name="user-content-select-fragment" id="select-fragment"></a> `<SelectFragment>`: Generate options for external source
 
 You may think want to build also the data source through jsx-slack. `<SelectFragment>` component can create JSON object for external data source usable in `<ExternalSelect>`.
 
@@ -253,7 +253,7 @@ app.get('/external-data-source', (req, res) => {
 app.listen(80)
 ```
 
-### <a name="users-select" id="users-select"></a> [`<UsersSelect>`: Select menu with user list](https://api.slack.com/reference/messaging/block-elements#users_select)
+### <a name="user-content-users-select" id="users-select"></a> [`<UsersSelect>`: Select menu with user list](https://api.slack.com/reference/messaging/block-elements#users_select)
 
 A select menu with options consisted of users in the current workspace.
 
@@ -278,7 +278,7 @@ A select menu with options consisted of users in the current workspace.
 - `required` (optional): A boolean prop to specify whether any value must be filled when user confirms modal.
 - `dispatchAction` (optional): By setting `true`, the input element will dispatch [`block_actions` payload](https://api.slack.com/reference/interaction-payloads/block-actions) when used this.
 
-### <a name="conversations-select" id="conversations-select"></a> [`<ConversationsSelect>`: Select menu with conversations list](https://api.slack.com/reference/messaging/block-elements#conversation_select)
+### <a name="user-content-conversations-select" id="conversations-select"></a> [`<ConversationsSelect>`: Select menu with conversations list](https://api.slack.com/reference/messaging/block-elements#conversation_select)
 
 A select menu with options consisted of any type of conversations in the current workspace.
 
@@ -336,7 +336,7 @@ By previewing the above JSX through [Slack Developer Tools](https://devtools.bui
 
 > :warning: `current` actually corresponds to [`default_to_current_conversation` field](https://api.slack.com/reference/block-kit/block-elements#conversation_multi_select) in Slack API. It will be ignored if defined initial conversations, so _multiple conversations select cannot specify `current` along with specific conversations_.
 
-### <a name="channels-select" id="channels-select"></a> [`<ChannelsSelect>`: Select menu with channel list](https://api.slack.com/reference/messaging/block-elements#channel_select)
+### <a name="user-content-channels-select" id="channels-select"></a> [`<ChannelsSelect>`: Select menu with channel list](https://api.slack.com/reference/messaging/block-elements#channel_select)
 
 A select menu with options consisted of public channels in the current workspace.
 
@@ -362,7 +362,7 @@ A select menu with options consisted of public channels in the current workspace
 - `dispatchAction` (optional): By setting `true`, the input element will dispatch [`block_actions` payload](https://api.slack.com/reference/interaction-payloads/block-actions) when used this.
 - `responseUrlEnabled` (optional): A boolean prop whether include extra `response_urls` field to the `view_submission` event callback, for responding into selected channel via unique URL entrypoint. _This is only available in modal's input component and cannot coexist with `multiple` prop._
 
-### <a name="overflow" id="overflow"></a> [`<Overflow>`: Overflow menu](https://api.slack.com/reference/messaging/block-elements#overflow)
+### <a name="user-content-overflow" id="overflow"></a> [`<Overflow>`: Overflow menu](https://api.slack.com/reference/messaging/block-elements#overflow)
 
 An overflow menu displayed as `...` can access to some hidden menu items. It must contain 1 to 5 `<OverflowItem>` component(s).
 
@@ -385,14 +385,14 @@ An overflow menu displayed as `...` can access to some hidden menu items. It mus
 - `name` / `actionId` (optional): An identifier for the action.
 - `confirm` (optional): [Confirmation dialog object] or [`<Confirm>` element](#confirm) to show confirmation dialog.
 
-### <a name="overflow-item" id="overflow-item"></a> `<OverflowItem>`: Menu item in overflow menu
+### <a name="user-content-overflow-item" id="overflow-item"></a> `<OverflowItem>`: Menu item in overflow menu
 
 #### Props
 
 - `value` (optional): A string value to send to Slack App when choose item.
 - `url` (optional): URL to load when clicked button.
 
-### <a name="date-picker" id="date-picker"></a> [`<DatePicker>`: Select date from calendar](https://api.slack.com/reference/messaging/block-elements#datepicker)
+### <a name="user-content-date-picker" id="date-picker"></a> [`<DatePicker>`: Select date from calendar](https://api.slack.com/reference/messaging/block-elements#datepicker)
 
 An easy way to let the user selecting any date is using `<DatePicker>` component.
 
@@ -434,7 +434,7 @@ An easy way to let the user selecting any date is using `<DatePicker>` component
 - `required` (optional): A boolean prop to specify whether any value must be filled when user confirms modal.
 - `dispatchAction` (optional): By setting `true`, the input element will dispatch [`block_actions` payload](https://api.slack.com/reference/interaction-payloads/block-actions) when used this.
 
-### <a name="time-picker" id="time-picker"></a> [`<TimePicker>`: Select time through picker](https://api.slack.com/reference/messaging/block-elements#timepicker)
+### <a name="user-content-time-picker" id="time-picker"></a> [`<TimePicker>`: Select time through picker](https://api.slack.com/reference/messaging/block-elements#timepicker)
 
 `<TimePicker>` component lets users input or select a specific time easily.
 
@@ -474,7 +474,7 @@ An easy way to let the user selecting any date is using `<DatePicker>` component
 - `required` (optional): A boolean prop to specify whether any value must be filled when user confirms modal.
 - `dispatchAction` (optional): By setting `true`, the input element will dispatch [`block_actions` payload](https://api.slack.com/reference/interaction-payloads/block-actions) when used this.
 
-### <a name="checkbox-group" id="checkbox-group"></a> [`<CheckboxGroup>`: Checkbox group](https://api.slack.com/reference/block-kit/block-elements#checkboxes)
+### <a name="user-content-checkbox-group" id="checkbox-group"></a> [`<CheckboxGroup>`: Checkbox group](https://api.slack.com/reference/block-kit/block-elements#checkboxes)
 
 A container for grouping checkboxes.
 
@@ -561,7 +561,7 @@ A container for grouping checkboxes.
 - `required` (optional): A boolean prop to specify whether any value must be filled when user confirms modal.
 - `dispatchAction` (optional): By setting `true`, the input element will dispatch [`block_actions` payload](https://api.slack.com/reference/interaction-payloads/block-actions) when used this.
 
-### <a name="checkbox" id="checkbox"></a> `<Checkbox>`: Checkbox
+### <a name="user-content-checkbox" id="checkbox"></a> `<Checkbox>`: Checkbox
 
 A checkbox item. It must place in the children of `<CheckboxGroup>`.
 
@@ -605,7 +605,7 @@ A below checkbox is meaning exactly the same as an example shown earlier.
 </Checkbox>
 ```
 
-### <a name="radio-button-group" id="radio-button-group"></a> [`<RadioButtonGroup>`: Radio button group](https://api.slack.com/reference/block-kit/block-elements#radio)
+### <a name="user-content-radio-button-group" id="radio-button-group"></a> [`<RadioButtonGroup>`: Radio button group](https://api.slack.com/reference/block-kit/block-elements#radio)
 
 A container for grouping radio buttons.
 
@@ -688,7 +688,7 @@ A container for grouping radio buttons.
 - `required` (optional): A boolean prop to specify whether any value must be filled when user confirms modal.
 - `dispatchAction` (optional): By setting `true`, the input element will dispatch [`block_actions` payload](https://api.slack.com/reference/interaction-payloads/block-actions) when used this.
 
-### <a name="radio-button" id="radio-button"></a> `<RadioButton>`: Radio button
+### <a name="user-content-radio-button" id="radio-button"></a> `<RadioButton>`: Radio button
 
 An item of the radio button. It must place in the children of `<RadioButtonGroup>`.
 
@@ -727,7 +727,7 @@ A below radio button is meaning exactly the same as an example shown earlier.
 
 ## [Composition objects](https://api.slack.com/reference/messaging/composition-objects)
 
-### <a name="confirm" id="confirm"></a> [`<Confirm>`: Confirmation dialog](https://api.slack.com/reference/messaging/composition-objects#confirm)
+### <a name="user-content-confirm" id="confirm"></a> [`<Confirm>`: Confirmation dialog](https://api.slack.com/reference/messaging/composition-objects#confirm)
 
 Define confirmation dialog. Many interactive elements can open confirmation dialog when selected, by passing `<Confirm>` to `confirm` prop.
 
@@ -766,7 +766,7 @@ You can use [HTML-like formatting](./html-like-formatting.md) to the content of 
   - `primary`: Green button on desktop, and blue text on mobile. (Slack's default if not defined)
   - `danger`: Red button on desktop, and red text on mobile.
 
-### <a name="mrkdwn" id="mrkdwn"></a> [`<Mrkdwn>`: Text composition object for `mrkdwn` type](https://api.slack.com/reference/block-kit/composition-objects#text)
+### <a name="user-content-mrkdwn" id="mrkdwn"></a> [`<Mrkdwn>`: Text composition object for `mrkdwn` type](https://api.slack.com/reference/block-kit/composition-objects#text)
 
 Generates text composition object for `mrkdwn` type.
 
@@ -868,7 +868,7 @@ The list of input components is following:
 - [`<CheckboxGroup>`](#checkbox-group)
 - [`<RadioButtonGroup>`](#radio-button-group)
 
-### <a name="input" id="input"></a> [`<Input>`: Plain-text input element](https://api.slack.com/reference/block-kit/block-elements#input)
+### <a name="user-content-input" id="input"></a> [`<Input>`: Plain-text input element](https://api.slack.com/reference/block-kit/block-elements#input)
 
 `<Input>` component is for placing a single-line input form within supported container. It can place as children of the container component directly.
 
@@ -882,7 +882,7 @@ It has an interface similar to `<input>` HTML element and `<input>` intrinsic HT
 
 [<img src="./preview-btn.svg" width="240" />](https://jsx-slack.netlify.app/#bkb:jsx:eJyz8c1PScxRKMksyUm1VfKtVHAsKFCy41JQsPHMKygtUchJTErNsVUKAckrKeQl5gJVlUA4uYkVPql56SUZtkoWBkoKRamFpZlFqSkK-nZcNvpgY-0AosweLg==)
 
-#### <a name="input-props" id="input-props"></a> Props
+#### <a name="user-content-input-props" id="input-props"></a> Props
 
 - `label` (**required**): The label string for the element.
 - `id` / `blockId` (optional): A string of unique identifier for [`<Input>` layout block](layout-blocks.md#input).
@@ -899,7 +899,7 @@ It has an interface similar to `<input>` HTML element and `<input>` intrinsic HT
 - `minLength` (optional): The minimum number of characters allowed for the input element.
 - `autoFocus` (optional): Set whether the element will be set the focus automatically within the modal/home container.
 
-### <a name="input-hidden" id="input-hidden"></a> `<Input type="hidden">`: Store hidden values to the parent `<Modal>` and `<Home>`
+### <a name="user-content-input-hidden" id="input-hidden"></a> `<Input type="hidden">`: Store hidden values to the parent `<Modal>` and `<Home>`
 
 By using `<Input type="hidden">`, you can assign hidden values as the private metadata JSON of the parent `<Modal>` or `<Home>` with a familiar way in HTML form.
 
@@ -973,7 +973,7 @@ In this example, the value of `private_metadata` field in returned payload would
 
 The transformer takes an argument: JSON object of hidden values or `undefined` when there was no hidden values. It must return the transformed string, or `undefined` if won't assign private metadata.
 
-### <a name="input-submit" id="input-submit"></a> `<Input type="submit">`: Set submit button text of modal
+### <a name="user-content-input-submit" id="input-submit"></a> `<Input type="submit">`: Set submit button text of modal
 
 `<Input type="submit">` can set the label of submit button for the current modal. It is meaning just an alias into `submit` prop of `<Modal>`, but JSX looks like more natural HTML form.
 
@@ -991,7 +991,7 @@ The transformer takes an argument: JSON object of hidden values or `undefined` w
 - `type` (**required**): Must be `submit`.
 - `value` (**required**): A string of submit button for the current modal. (24 characters maximum)
 
-### <a name="textarea" id="textarea"></a> `<Textarea>`: Plain-text input element with multiline
+### <a name="user-content-textarea" id="textarea"></a> `<Textarea>`: Plain-text input element with multiline
 
 `<Textarea>` component has very similar interface to [`<Input>` input component](#input). An only difference is to allow multi-line input.
 

--- a/docs/block-elements.md
+++ b/docs/block-elements.md
@@ -123,7 +123,7 @@ By passing suitable props such as required `label` prop, select-like components 
 
 [<img src="./preview-btn.svg" width="240" />](https://jsx-slack.netlify.app/#bkb:jsx:eJx9kMEKwjAMhu8-Rahn3Qt0vXgRURzsCWIXtmrXzq6d7O2tLQMF2Sl__nz5A-EX26AGr7ymklXOtg77XpkWxuAmmpnYAPCaNEkfFYDGG-mSndG0AVtiyTTYx2394y2RSj5gmcBsA7zQePAWNKEz-ww7egblqImNSAa_Dl5ZAxPqEFPuOOEonRo8E6eo66R5kam_K8PsO2uYqFJdRT_pOXcVk7uxQzcwcdiuX-4iUx2rb4gX-Ydiw4v0cvEGXNR5RA==)
 
-The above JSX means exactly same as following usage of [`<Input>` layout block](layout-blocks.md#input):
+The above JSX means exactly same as following usage of [`<Input>` layout block](layout-blocks.md#user-content-input):
 
 <!-- prettier-ignore-start -->
 
@@ -142,7 +142,7 @@ The above JSX means exactly same as following usage of [`<Input>` layout block](
 ##### Props for an input component
 
 - `label` (**required**): The label string for the element.
-- `id` / `blockId` (optional): A string of unique identifier of [`<Input>` layout block](layout-blocks.md#input).
+- `id` / `blockId` (optional): A string of unique identifier of [`<Input>` layout block](layout-blocks.md#user-content-input).
 - `title`/ `hint` (optional): Specify a helpful text appears under the element.
 - `required` (optional): A boolean prop to specify whether any value must be filled when user confirms modal.
 - `dispatchAction` (optional): By setting `true`, the input element will dispatch [`block_actions` payload](https://api.slack.com/reference/interaction-payloads/block-actions) when used this.
@@ -221,7 +221,7 @@ It requires setup JSON entry URL in your Slack app. [Learn about external source
 ##### Props for an input component
 
 - `label` (**required**): The label string for the element.
-- `id` / `blockId` (optional): A string of unique identifier of [`<Input>` layout block](layout-blocks.md#input).
+- `id` / `blockId` (optional): A string of unique identifier of [`<Input>` layout block](layout-blocks.md#user-content-input).
 - `title`/ `hint` (optional): Specify a helpful text appears under the element.
 - `required` (optional): A boolean prop to specify whether any value must be filled when user confirms modal.
 - `dispatchAction` (optional): By setting `true`, the input element will dispatch [`block_actions` payload](https://api.slack.com/reference/interaction-payloads/block-actions) when used this.
@@ -232,7 +232,7 @@ You may think want to build also the data source through jsx-slack. `<SelectFrag
 
 #### Example
 
-A following is a super simple example to serve JSON for external select via [express](https://expressjs.com/). It is using [`jsxslack` tagged template literal](../README.md#quick-start-template-literal).
+A following is a super simple example to serve JSON for external select via [express](https://expressjs.com/). It is using [`jsxslack` tagged template literal](../README.md#user-content-quick-start-template-literal).
 
 ```javascript
 import { jsxslack } from 'jsx-slack'
@@ -273,7 +273,7 @@ A select menu with options consisted of users in the current workspace.
 ##### Props for an input component
 
 - `label` (**required**): The label string for the element.
-- `id` / `blockId` (optional): A string of unique identifier of [`<Input>` layout block](layout-blocks.md#input).
+- `id` / `blockId` (optional): A string of unique identifier of [`<Input>` layout block](layout-blocks.md#user-content-input).
 - `title`/ `hint` (optional): Specify a helpful text appears under the element.
 - `required` (optional): A boolean prop to specify whether any value must be filled when user confirms modal.
 - `dispatchAction` (optional): By setting `true`, the input element will dispatch [`block_actions` payload](https://api.slack.com/reference/interaction-payloads/block-actions) when used this.
@@ -305,7 +305,7 @@ A select menu with options consisted of any type of conversations in the current
 ##### Props for an input component
 
 - `label` (**required**): The label string for the element.
-- `id` / `blockId` (optional): A string of unique identifier of [`<Input>` layout block](layout-blocks.md#input).
+- `id` / `blockId` (optional): A string of unique identifier of [`<Input>` layout block](layout-blocks.md#user-content-input).
 - `title`/ `hint` (optional): Specify a helpful text appears under the element.
 - `required` (optional): A boolean prop to specify whether any value must be filled when user confirms modal.
 - `dispatchAction` (optional): By setting `true`, the input element will dispatch [`block_actions` payload](https://api.slack.com/reference/interaction-payloads/block-actions) when used this.
@@ -356,7 +356,7 @@ A select menu with options consisted of public channels in the current workspace
 ##### Props for an input component
 
 - `label` (**required**): The label string for the element.
-- `id` / `blockId` (optional): A string of unique identifier of [`<Input>` layout block](layout-blocks.md#input).
+- `id` / `blockId` (optional): A string of unique identifier of [`<Input>` layout block](layout-blocks.md#user-content-input).
 - `title`/ `hint` (optional): Specify a helpful text appears under the element.
 - `required` (optional): A boolean prop to specify whether any value must be filled when user confirms modal.
 - `dispatchAction` (optional): By setting `true`, the input element will dispatch [`block_actions` payload](https://api.slack.com/reference/interaction-payloads/block-actions) when used this.
@@ -429,7 +429,7 @@ An easy way to let the user selecting any date is using `<DatePicker>` component
 ##### Props for an input component
 
 - `label` (**required**): The label string for the element.
-- `id` / `blockId` (optional): A string of unique identifier of [`<Input>` layout block](layout-blocks.md#input).
+- `id` / `blockId` (optional): A string of unique identifier of [`<Input>` layout block](layout-blocks.md#user-content-input).
 - `title`/ `hint` (optional): Specify a helpful text appears under the element.
 - `required` (optional): A boolean prop to specify whether any value must be filled when user confirms modal.
 - `dispatchAction` (optional): By setting `true`, the input element will dispatch [`block_actions` payload](https://api.slack.com/reference/interaction-payloads/block-actions) when used this.
@@ -469,7 +469,7 @@ An easy way to let the user selecting any date is using `<DatePicker>` component
 ##### Props for an input component
 
 - `label` (**required**): The label string for the element.
-- `id` / `blockId` (optional): A string of unique identifier of [`<Input>` layout block](layout-blocks.md#input).
+- `id` / `blockId` (optional): A string of unique identifier of [`<Input>` layout block](layout-blocks.md#user-content-input).
 - `title`/ `hint` (optional): Specify a helpful text appears under the element.
 - `required` (optional): A boolean prop to specify whether any value must be filled when user confirms modal.
 - `dispatchAction` (optional): By setting `true`, the input element will dispatch [`block_actions` payload](https://api.slack.com/reference/interaction-payloads/block-actions) when used this.
@@ -556,7 +556,7 @@ A container for grouping checkboxes.
 ##### Props for an input component
 
 - `label` (**required**): The label string for the group.
-- `id` / `blockId` (optional): A string of unique identifier of [`<Input>` layout block](layout-blocks.md#input).
+- `id` / `blockId` (optional): A string of unique identifier of [`<Input>` layout block](layout-blocks.md#user-content-input).
 - `title`/ `hint` (optional): Specify a helpful text appears under the group.
 - `required` (optional): A boolean prop to specify whether any value must be filled when user confirms modal.
 - `dispatchAction` (optional): By setting `true`, the input element will dispatch [`block_actions` payload](https://api.slack.com/reference/interaction-payloads/block-actions) when used this.
@@ -582,7 +582,7 @@ It supports raw [mrkdwn format](https://api.slack.com/reference/surfaces/formatt
 
 [<img src="./preview-btn.svg" width="240" />](https://jsx-slack.netlify.app/#bkb:jsx:eJxlj80KwjAQhO8-xdJ7Wfw5yRoQD_YR4jEpEZcmrqSJ6NtbtX_ibWf5hpmhSoJTCwDa14nl2r7vTh0urm6sPI5R8u37m33hbnx2u6LudTEQHWPVSHFygdCqLZxFrIkT1Abj_WQC0FqXy9V6AyUQK_uEU24YKpOSRCbkWQD-mAmHuL45_lUnHLcRfva-AG1pRKg=)
 
-> :information_source: [Links and mentions through `<a>` tag](https://github.com/yhatt/jsx-slack/blob/main/docs/html-like-formatting.md#links) will be ignored by Slack.
+> :information_source: [Links and mentions through `<a>` tag](https://github.com/yhatt/jsx-slack/blob/main/docs/html-like-formatting.md#user-content-links) will be ignored by Slack.
 
 #### Props
 
@@ -683,7 +683,7 @@ A container for grouping radio buttons.
 ##### Props for an input component
 
 - `label` (**required**): The label string for the group.
-- `id` / `blockId` (optional): A string of unique identifier of [`<Input>` layout block](layout-blocks.md#input).
+- `id` / `blockId` (optional): A string of unique identifier of [`<Input>` layout block](layout-blocks.md#user-content-input).
 - `title`/ `hint` (optional): Specify a helpful text appears under the group.
 - `required` (optional): A boolean prop to specify whether any value must be filled when user confirms modal.
 - `dispatchAction` (optional): By setting `true`, the input element will dispatch [`block_actions` payload](https://api.slack.com/reference/interaction-payloads/block-actions) when used this.
@@ -702,7 +702,7 @@ It supports raw [mrkdwn format](https://api.slack.com/reference/surfaces/formatt
 
 [<img src="./preview-btn.svg" width="240" />](https://jsx-slack.netlify.app/#bkb:jsx:eJyz8cjPTbXjUlCwcUwuyczPKwaxgbygxJTMfKfSkpL8PPei_NICiDCqhEJZYk5pqq1SEUhICaYCqCbJDqxKIQmszEY_CUmuODcxJwfBB4pk2rmkFicXZRaA7LfRz0RSrI-i2kYfyXKoO_WxOdRGH-4ZG32wBwHp90Hi)
 
-> :information_source: [Links and mentions through `<a>` tag](https://github.com/yhatt/jsx-slack/blob/main/docs/html-like-formatting.md#links) will be ignored by Slack.
+> :information_source: [Links and mentions through `<a>` tag](https://github.com/yhatt/jsx-slack/blob/main/docs/html-like-formatting.md#user-content-links) will be ignored by Slack.
 
 #### Props
 
@@ -852,7 +852,7 @@ jsx-slack will disable automatic parsing by default even if you were not used `<
 
 **Input components** are available in every containers. These include a part of [interactive components](#interactive-components) and dedicated components such as [`<Input>`](#input) and [`<Textarea>`](#textarea).
 
-All of input components **must be placed as the direct children of the container component, and defining `label` prop is required.** (for [`<Input>` layout block](layout-blocks.md#input))
+All of input components **must be placed as the direct children of the container component, and defining `label` prop is required.** (for [`<Input>` layout block](layout-blocks.md#user-content-input))
 
 The list of input components is following:
 
@@ -885,7 +885,7 @@ It has an interface similar to `<input>` HTML element and `<input>` intrinsic HT
 #### <a name="user-content-input-props" id="input-props"></a> Props
 
 - `label` (**required**): The label string for the element.
-- `id` / `blockId` (optional): A string of unique identifier for [`<Input>` layout block](layout-blocks.md#input).
+- `id` / `blockId` (optional): A string of unique identifier for [`<Input>` layout block](layout-blocks.md#user-content-input).
 - `name` / `actionId` (optional): A string of unique identifier for the action.
 - `type` (optional): `text` by default.
 - `title`/ `hint` (optional): Specify a helpful text appears under the element.

--- a/docs/how-to-setup-jsx-transpiler.md
+++ b/docs/how-to-setup-jsx-transpiler.md
@@ -9,7 +9,7 @@
 - [Deno](#deno) (Slack CLI)
 - [esbuild](#esbuild)
 
-## [Babel](https://babeljs.io/) <a name="babel"></a>
+## [Babel](https://babeljs.io/) <a name="user-content-babel" id="babel"></a>
 
 You can use [`@babel/preset-react`](https://babeljs.io/docs/en/babel-preset-react) preset (or [`@babel/plugin-transform-react-jsx`](https://babeljs.io/docs/en/babel-plugin-transform-react-jsx) plugin) to transpile JSX.
 
@@ -99,7 +99,7 @@ const { JSXSlack } = require('jsx-slack')
 
 </details>
 
-## [TypeScript](https://www.typescriptlang.org/) <a name="typescript"></a>
+## [TypeScript](https://www.typescriptlang.org/) <a name="user-content-typescript" id="typescript"></a>
 
 JSX (TSX) transpile in TypeScript can be used in some of different ways.
 
@@ -134,7 +134,7 @@ Or you can instruct to use jsx-slack in all TSX files by setting up `tsconfig.js
 }
 ```
 
-###### Classic (TypeScript <= 4.0 and esbuild) <a name="typescript-classic"></a>
+###### Classic (TypeScript <= 4.0 and esbuild) <a name="user-content-typescript-classic" id="typescript-classic"></a>
 
 If your using build tool has not yet supported TypeScript `react-jsx` mode, try using a classic `react` mode.
 
@@ -204,7 +204,7 @@ api.chat.postMessage({
 })
 ```
 
-## [Deno](https://deno.land/) (Slack CLI) <a name="deno"></a>
+## [Deno](https://deno.land/) (Slack CLI) <a name="user-content-deno" id="deno"></a>
 
 _Please note that [it requires Deno v1.16 and later](https://deno.com/blog/v1.16#support-for-new-jsx-transforms)._
 
@@ -239,7 +239,7 @@ console.log(
 }
 ```
 
-###### Classic (Deno <= 1.15) <a name="typescript-classic"></a>
+###### Classic (Deno <= 1.15) <a name="user-content-deno-classic" id="deno-classic"></a>
 
 <details>
 <summary>How to transpile JSX with classic way in Deno... 👉</summary>
@@ -301,7 +301,7 @@ import { Blocks, Section } from 'jsx-slack'
 
 This will make your JSX/TSX source codes compatible with Node.js. In addition, the import maps also helpful for using alternative ESM CDN like [skypack.dev](https://skypack.dev/). [See the Deno manual for more details.](https://deno.land/manual@v1.16.0/jsx_dom/jsx#using-an-import-map)
 
-## [esbuild](https://esbuild.github.io/) <a name="esbuild"></a>
+## [esbuild](https://esbuild.github.io/) <a name="user-content-esbuild" id="esbuild"></a>
 
 esbuild does not have supported JSX automatic runtime ([evanw/esbuild#334](https://github.com/evanw/esbuild/issues/334)) so you have to always use the classic way to transpile JSX.
 

--- a/docs/how-to-setup-jsx-transpiler.md
+++ b/docs/how-to-setup-jsx-transpiler.md
@@ -2,7 +2,7 @@
 
 # How to setup JSX transpiler
 
-[jsx-slack can use without transpiler by using `jsxslack` template literal tag](<(../README.md#quick-start-template-literal)>), but we strongly recommend to set up JSX in the transpiler because you'll get better developer experience in IDE (e.g. Auto completion, static error check, etc...)
+[jsx-slack can use without transpiler by using `jsxslack` template literal tag](../README.md#user-content-quick-start-template-literal), but we strongly recommend to set up JSX in the transpiler because you'll get better developer experience in IDE (e.g. Auto completion, static error check, etc...)
 
 - [Babel](#babel)
 - [TypeScript](#typescript)

--- a/docs/html-like-formatting.md
+++ b/docs/html-like-formatting.md
@@ -10,7 +10,7 @@ jsx-slack has HTML-compatible JSX elements to format messages. It might be verbo
 
 _Using these HTML elements is not mandatory. You may also use [the regular mrkdwn syntax][mrkdwn] to format if necessary_: `_italic_`, `*bold*`, `~strike~`, `` `code` ``, `> quote`, and ` ```code block``` `.
 
-If you want to prevent parsing special characters for regular mrkdwn, we recommend to consider using [`<Escape>` component](about-escape-and-exact-mode.md#special-characters).
+If you want to prevent parsing special characters for regular mrkdwn, we recommend to consider using [`<Escape>` component](about-escape-and-exact-mode.md#user-content-special-characters).
 
 [mrkdwn]: https://api.slack.com/reference/surfaces/formatting
 
@@ -99,7 +99,7 @@ As same as HTML, `<ol>` tag supports [`start` and `type` attribute](https://deve
 
 ## Links
 
-jsx-slack will not recognize URL-like string as hyperlink unless using [`<Mrkdwn verbatim={false}>`](block-elements.md#mrkdwn). Generally you should use `<a>` tag whenever you want to use a link.
+jsx-slack will not recognize URL-like string as hyperlink unless using [`<Mrkdwn verbatim={false}>`](block-elements.md#user-content-mrkdwn). Generally you should use `<a>` tag whenever you want to use a link.
 
 For example, `<a href="https://example.com/">Link</a>` will be converted to `<https://example.com/|Link>`.
 

--- a/docs/jsx-components-for-block-kit.md
+++ b/docs/jsx-components-for-block-kit.md
@@ -4,62 +4,62 @@
 
 ## **[Block containers](block-containers.md)**
 
-- [**`<Blocks>`**: The basic container for messages](block-containers.md#blocks)
-- [**`<Modal>`**: The view container for modals](block-containers.md#modal)
-- [**`<Home>`**: The view container for home tabs](block-containers.md#home)
+- [**`<Blocks>`**: The basic container for messages](block-containers.md#user-content-blocks)
+- [**`<Modal>`**: The view container for modals](block-containers.md#user-content-modal)
+- [**`<Home>`**: The view container for home tabs](block-containers.md#user-content-home)
 
 ## **[Layout blocks](layout-blocks.md)**
 
-- [**`<Section>`**: Section Block](layout-blocks.md#section)
-  - [**`<Field>`**: Fields for section block](layout-blocks.md#field)
-- [**`<Divider>`**: Divider Block](layout-blocks.md#divider)
-- [**`<Image>`**: Image Block](layout-blocks.md#image)
-- [**`<Header>`**: Header Block](layout-blocks.md#header)
-- [**`<Actions>`**: Actions Block](layout-blocks.md#actions)
-- [**`<Context>`**: Context Block](layout-blocks.md#context)
-- [**`<Input>`**: Input Block](layout-blocks.md#input)
-- [**`<Video>`**: Video Block](layout-blocks.md#video)
-- [**`<File>`**: File Block](layout-blocks.md#file) (Only for messaging)
-- [**`<Call>`**: Call Block](layout-blocks.md#call) (Only for messaging)
+- [**`<Section>`**: Section Block](layout-blocks.md#user-content-section)
+  - [**`<Field>`**: Fields for section block](layout-blocks.md#user-content-field)
+- [**`<Divider>`**: Divider Block](layout-blocks.md#user-content-divider)
+- [**`<Image>`**: Image Block](layout-blocks.md#user-content-image)
+- [**`<Header>`**: Header Block](layout-blocks.md#user-content-header)
+- [**`<Actions>`**: Actions Block](layout-blocks.md#user-content-actions)
+- [**`<Context>`**: Context Block](layout-blocks.md#user-content-context)
+- [**`<Input>`**: Input Block](layout-blocks.md#user-content-input)
+- [**`<Video>`**: Video Block](layout-blocks.md#user-content-video)
+- [**`<File>`**: File Block](layout-blocks.md#user-content-file) (Only for messaging)
+- [**`<Call>`**: Call Block](layout-blocks.md#user-content-call) (Only for messaging)
 
 ## **[Block elements](block-elements.md)**
 
-### **[Interactive components](block-elements.md#interactive-components)**
+### **[Interactive components](block-elements.md#user-content-interactive-components)**
 
-- [**`<Button>`**: Button element](block-elements.md#button)
-- [**`<Select>`**: Select menu with static options](block-elements.md#select)
-  - [**`<Option>`**: Menu item](block-elements.md#option)
-  - [**`<Optgroup>`**: Group of menu items](block-elements.md#optgroup)
-- [**`<ExternalSelect>`**: Select menu with external data source](block-elements.md#external-select)
-  - [**`<SelectFragment>`**: Generate options for external source](block-elements.md#select-fragment)
-- [**`<UsersSelect>`**: Select menu with user list](block-elements.md#users-select)
-- [**`<ConversationsSelect>`**: Select menu with conversations list](block-elements.md#conversations-select)
-- [**`<ChannelsSelect>`**: Select menu with channel list](block-elements.md#channels-select)
-- [**`<Overflow>`**: Overflow menu](block-elements.md#overflow)
-  - [**`<OverflowItem>`**: Menu item in overflow menu](block-elements.md#overflow-item)
-- [**`<DatePicker>`**: Select date from calendar](block-elements.md#date-picker)
-- [**`<TimePicker>`**: Select time through picker](block-elements.md#time-picker)
-- [**`<CheckboxGroup>`**: Checkbox group](block-elements.md#checkbox-group)
-  - [**`<Checkbox>`**: Checkbox](block-elements.md#checkbox)
-- [**`<RadioButtonGroup>`**: Radio button group](block-elements.md#radio-button-group)
-  - [**`<RadioButton>`**: Radio button](block-elements.md#radio-button)
+- [**`<Button>`**: Button element](block-elements.md#user-content-button)
+- [**`<Select>`**: Select menu with static options](block-elements.md#user-content-select)
+  - [**`<Option>`**: Menu item](block-elements.md#user-content-option)
+  - [**`<Optgroup>`**: Group of menu items](block-elements.md#user-content-optgroup)
+- [**`<ExternalSelect>`**: Select menu with external data source](block-elements.md#user-content-external-select)
+  - [**`<SelectFragment>`**: Generate options for external source](block-elements.md#user-content-select-fragment)
+- [**`<UsersSelect>`**: Select menu with user list](block-elements.md#user-content-users-select)
+- [**`<ConversationsSelect>`**: Select menu with conversations list](block-elements.md#user-content-conversations-select)
+- [**`<ChannelsSelect>`**: Select menu with channel list](block-elements.md#user-content-channels-select)
+- [**`<Overflow>`**: Overflow menu](block-elements.md#user-content-overflow)
+  - [**`<OverflowItem>`**: Menu item in overflow menu](block-elements.md#user-content-overflow-item)
+- [**`<DatePicker>`**: Select date from calendar](block-elements.md#user-content-date-picker)
+- [**`<TimePicker>`**: Select time through picker](block-elements.md#user-content-time-picker)
+- [**`<CheckboxGroup>`**: Checkbox group](block-elements.md#user-content-checkbox-group)
+  - [**`<Checkbox>`**: Checkbox](block-elements.md#user-content-checkbox)
+- [**`<RadioButtonGroup>`**: Radio button group](block-elements.md#user-content-radio-button-group)
+  - [**`<RadioButton>`**: Radio button](block-elements.md#user-content-radio-button)
 
-### **[Composition objects](block-elements.md#composition-objects)**
+### **[Composition objects](block-elements.md#user-content-composition-objects)**
 
-- [**`<Confirm>`**: Confirmation dialog](block-elements.md#confirm)
-- [**`<Mrkdwn>`**: Text composition object for `mrkdwn` type](block-elements.md#mrkdwn)
+- [**`<Confirm>`**: Confirmation dialog](block-elements.md#user-content-confirm)
+- [**`<Mrkdwn>`**: Text composition object for `mrkdwn` type](block-elements.md#user-content-mrkdwn)
 
-### **[Input components](block-elements.md#input-components)**
+### **[Input components](block-elements.md#user-content-input-components)**
 
-- [**`<Input>`**: Plain-text input element](block-elements.md#input)
-  - [**`<Input type="hidden">`**: Store hidden values to `<Modal>` and `<Home>`](block-elements.md#input-hidden)
-  - [**`<Input type="submit">`**: Set submit button text of modal](block-elements.md#input-submit)
-- [**`<Textarea>`**: Plain-text input element with multiline](block-elements.md#textarea)
+- [**`<Input>`**: Plain-text input element](block-elements.md#user-content-input)
+  - [**`<Input type="hidden">`**: Store hidden values to `<Modal>` and `<Home>`](block-elements.md#user-content-input-hidden)
+  - [**`<Input type="submit">`**: Set submit button text of modal](block-elements.md#user-content-input-submit)
+- [**`<Textarea>`**: Plain-text input element with multiline](block-elements.md#user-content-textarea)
 
 ## Built-in components
 
-- [**`<Fragment>`**: Grouping components](../README.md#fragments)
-- [**`<Escape>`**: Escape special characters](about-escape-and-exact-mode.md#escape)
+- [**`<Fragment>`**: Grouping components](../README.md#user-content-fragments)
+- [**`<Escape>`**: Escape special characters](about-escape-and-exact-mode.md#user-content-escape)
 
 ---
 

--- a/docs/layout-blocks.md
+++ b/docs/layout-blocks.md
@@ -44,17 +44,17 @@ A one of accessory component may include as the children of `<Section>`. The def
 #### Accessory components
 
 - [`<Image>`](#image) / `<img>`
-- [`<Button>`](block-elements.md#button) / `<button>`
-- [`<Select>`](block-elements.md#select) / `<select>`
-- [`<ExternalSelect>`](block-elements.md#external-select)
-- [`<UsersSelect>`](block-elements.md#users-select)
-- [`<ConversationsSelect>`](block-elements.md#conversations-select)
-- [`<ChannelsSelect>`](block-elements.md#channels-select)
-- [`<Overflow>`](block-elements.md#overflow)
-- [`<DatePicker>`](block-elements.md#date-picker)
-- [`<TimePicker>`](block-elements.md#time-picker)
-- [`<CheckboxGroup>`](block-elements.md#checkbox-group)
-- [`<RadioButtonGroup>`](block-elements.md#radio-button-group)
+- [`<Button>`](block-elements.md#user-content-button) / `<button>`
+- [`<Select>`](block-elements.md#user-content-select) / `<select>`
+- [`<ExternalSelect>`](block-elements.md#user-content-external-select)
+- [`<UsersSelect>`](block-elements.md#user-content-users-select)
+- [`<ConversationsSelect>`](block-elements.md#user-content-conversations-select)
+- [`<ChannelsSelect>`](block-elements.md#user-content-channels-select)
+- [`<Overflow>`](block-elements.md#user-content-overflow)
+- [`<DatePicker>`](block-elements.md#user-content-date-picker)
+- [`<TimePicker>`](block-elements.md#user-content-time-picker)
+- [`<CheckboxGroup>`](block-elements.md#user-content-checkbox-group)
+- [`<RadioButtonGroup>`](block-elements.md#user-content-radio-button-group)
 
 ### <a name="user-content-field" id="field"></a> `<Field>`: Fields for section block
 
@@ -130,7 +130,7 @@ Display a plain text in a larger and bold font. The same name `<header>` intrins
 
 [<img src="./preview-btn.svg" width="240" />](https://jsx-slack.netlify.app/#bkb:jsx:eJyzccrJT84utuNSULDxSE1MSS2yA1HFCqUFijb6UBEuG32oMgBi2w70)
 
-Please be aware that header layout block _only accepts the plain text_ for now. `<br />` will work but [most other HTML-like elements for styling](./html-like-formatting.md#basic-text-formatting) would not work.
+Please be aware that header layout block _only accepts the plain text_ for now. `<br />` will work but [most other HTML-like elements for styling](./html-like-formatting.md#user-content-basic-text-formatting) would not work.
 
 ### Props
 
@@ -138,7 +138,7 @@ Please be aware that header layout block _only accepts the plain text_ for now. 
 
 ## <a name="user-content-actions" id="actions"></a> [`<Actions>`: Actions Block](https://api.slack.com/reference/messaging/blocks#actions)
 
-A block to hold [interactive components](block-elements.md#interactive-components) provided by block elements. Slack allows a maximum of 25 interactive elements in `<Actions>` (But recommends to place up to 5 elements).
+A block to hold [interactive components](block-elements.md#user-content-interactive-components) provided by block elements. Slack allows a maximum of 25 interactive elements in `<Actions>` (But recommends to place up to 5 elements).
 
 ### Props
 
@@ -161,7 +161,7 @@ Display message context. It allows mixed contents consisted of texts and `<Image
 
 [<img src="./preview-btn.svg" width="240" />](https://jsx-slack.netlify.app/#bkb:jsx:eJyzccrJT84utuNSULBxzs8rSa0oAbGBvMzcdIXiomRbpYySkoJiK339gpzE5NTszJKS1Dy95PxcfUMDAxBWUkjMKbFV8gZLKCnoQ7Q7KkBUKiTmpVDDvNz8olSokXogt-rDHWujD_UCAJNMPX4=)
 
-Text contents will merge in pertinent mrkdwn elements automatically, but they also may divide clearly by using `<span>` HTML intrinsic element (or [`<Mrkdwn>` component](block-elements.md#mrkdwn) for text composition object).
+Text contents will merge in pertinent mrkdwn elements automatically, but they also may divide clearly by using `<span>` HTML intrinsic element (or [`<Mrkdwn>` component](block-elements.md#user-content-mrkdwn) for text composition object).
 
 ```jsx
 <Blocks>
@@ -212,21 +212,21 @@ If you want to use `<Input>` as layout block, you have to place one of [availabl
 
 ### Available interactive components
 
-- [`<Select>`](block-elements.md#select)
-- [`<ExternalSelect>`](block-elements.md#external-select)
-- [`<UsersSelect>`](block-elements.md#users-select)
-- [`<ConversationsSelect>`](block-elements.md#conversations-select) \*
-- [`<ChannelsSelect>`](block-elements.md#channels-select) \*
-- [`<DatePicker>`](block-elements.md#date-picker)
-- [`<TimePicker>`](block-elements.md#time-picker)
-- [`<CheckboxGroup>`](block-elements.md#checkbox-group)
-- [`<RadioButtonGroup>`](block-elements.md#radio-button-group)
+- [`<Select>`](block-elements.md#user-content-select)
+- [`<ExternalSelect>`](block-elements.md#user-content-external-select)
+- [`<UsersSelect>`](block-elements.md#user-content-users-select)
+- [`<ConversationsSelect>`](block-elements.md#user-content-conversations-select) \*
+- [`<ChannelsSelect>`](block-elements.md#user-content-channels-select) \*
+- [`<DatePicker>`](block-elements.md#user-content-date-picker)
+- [`<TimePicker>`](block-elements.md#user-content-time-picker)
+- [`<CheckboxGroup>`](block-elements.md#user-content-checkbox-group)
+- [`<RadioButtonGroup>`](block-elements.md#user-content-radio-button-group)
 
-> \* Some components have unique properties only for [input components](block-elements.md#input-components). You cannot define them to the interactive component wrapped in `<Input>` layout block _(TypeScript would throw error while compile)_.
+> \* Some components have unique properties only for [input components](block-elements.md#user-content-input-components). You cannot define them to the interactive component wrapped in `<Input>` layout block _(TypeScript would throw error while compile)_.
 
 ### Note
 
-**We usually recommend to use [input components](block-elements.md#input-components) directly** instead of using `<Input>` layout block. These, included [`<Input>`](block-elements.md#input) and [`<Textarea>`](block-elements.md#textarea), can place to modal directly by passing props compatible with `<Input>` block, and you may write JSX template with familiar HTML form style.
+**We usually recommend to use [input components](block-elements.md#user-content-input-components) directly** instead of using `<Input>` layout block. These, included [`<Input>`](block-elements.md#user-content-input) and [`<Textarea>`](block-elements.md#user-content-textarea), can place to modal directly by passing props compatible with `<Input>` block, and you may write JSX template with familiar HTML form style.
 
 ```jsx
 <Modal title="My App">
@@ -284,7 +284,7 @@ A block for embedding a video. The `<video>` intrinsic HTML element works as wel
 
 ## <a name="user-content-file" id="file"></a> [`<File>`: File Block](https://api.slack.com/reference/messaging/blocks#file) (Only for messaging)
 
-Display a remote file that was added to Slack workspace. [Learn about adding remote files in the document of Slack API.](https://api.slack.com/messaging/files/remote) _This block is only for [`<Blocks>` container](block-containers.md#blocks)._
+Display a remote file that was added to Slack workspace. [Learn about adding remote files in the document of Slack API.](https://api.slack.com/messaging/files/remote) _This block is only for [`<Blocks>` container](block-containers.md#user-content-blocks)._
 
 ```jsx
 <Blocks>
@@ -300,7 +300,7 @@ Display a remote file that was added to Slack workspace. [Learn about adding rem
 
 ## <a name="user-content-call" id="call"></a> `<Call>`: Call Block (Only for messaging)
 
-Display a card of the call that was registered to Slack workspace. [Learn about using the Calls API in the document of Slack API.](https://api.slack.com/apis/calls) _This block is only for [`<Blocks>` container](block-containers.md#blocks)._
+Display a card of the call that was registered to Slack workspace. [Learn about using the Calls API in the document of Slack API.](https://api.slack.com/apis/calls) _This block is only for [`<Blocks>` container](block-containers.md#user-content-blocks)._
 
 ```jsx
 <Blocks>

--- a/docs/layout-blocks.md
+++ b/docs/layout-blocks.md
@@ -6,7 +6,7 @@
 
 All of these blocks can use as the children of [all block containers](block-containers.md), unless there is specific requirements such as [`<File>`](#file) or [`<Call>`](#call).
 
-## <a name="section" id="section"></a> [`<Section>`: Section Block](https://api.slack.com/reference/messaging/blocks#section)
+## <a name="user-content-section" id="section"></a> [`<Section>`: Section Block](https://api.slack.com/reference/messaging/blocks#section)
 
 Display a simple text message. You have to specify the content as children. It allows [formatting with HTML-like elements](./html-like-formatting.md).
 
@@ -56,7 +56,7 @@ A one of accessory component may include as the children of `<Section>`. The def
 - [`<CheckboxGroup>`](block-elements.md#checkbox-group)
 - [`<RadioButtonGroup>`](block-elements.md#radio-button-group)
 
-### <a name="field" id="field"></a> `<Field>`: Fields for section block
+### <a name="user-content-field" id="field"></a> `<Field>`: Fields for section block
 
 In addition the text content, the section block also can use 2 columns texts called fields. In jsx-slack, you can define field by `<Field>` component in `<Section>` block.
 
@@ -83,7 +83,7 @@ In addition the text content, the section block also can use 2 columns texts cal
 
 > :information_source: Contents of `<Field>` would be placed after the main text contents even if placed them anywhere.
 
-## <a name="divider" id="divider"></a> [`<Divider>`: Divider Block](https://api.slack.com/reference/messaging/blocks#divider)
+## <a name="user-content-divider" id="divider"></a> [`<Divider>`: Divider Block](https://api.slack.com/reference/messaging/blocks#divider)
 
 Just a divider. `<hr>` intrinsic HTML element works as well.
 
@@ -99,7 +99,7 @@ Just a divider. `<hr>` intrinsic HTML element works as well.
 
 - `id` / `blockId` (optional): A string of unique identifier of block.
 
-## <a name="image" id="image"></a> [`<Image>`: Image Block](https://api.slack.com/reference/messaging/blocks#image)
+## <a name="user-content-image" id="image"></a> [`<Image>`: Image Block](https://api.slack.com/reference/messaging/blocks#image)
 
 Display an image block. It has well-known props like `<img>` HTML element. In fact, `<img>` intrinsic HTML element works as well.
 
@@ -118,7 +118,7 @@ Display an image block. It has well-known props like `<img>` HTML element. In fa
 - `title` (optional): An optional title for the image.
 - `id` / `blockId` (optional): A string of unique identifier of block.
 
-## <a name="header" id="header"></a> [`<Header>`: Header Block](https://api.slack.com/reference/messaging/blocks#header)
+## <a name="user-content-header" id="header"></a> [`<Header>`: Header Block](https://api.slack.com/reference/messaging/blocks#header)
 
 Display a plain text in a larger and bold font. The same name `<header>` intrinsic HTML element works as well.
 
@@ -136,7 +136,7 @@ Please be aware that header layout block _only accepts the plain text_ for now. 
 
 - `id` / `blockId` (optional): A string of unique identifier of block.
 
-## <a name="actions" id="actions"></a> [`<Actions>`: Actions Block](https://api.slack.com/reference/messaging/blocks#actions)
+## <a name="user-content-actions" id="actions"></a> [`<Actions>`: Actions Block](https://api.slack.com/reference/messaging/blocks#actions)
 
 A block to hold [interactive components](block-elements.md#interactive-components) provided by block elements. Slack allows a maximum of 25 interactive elements in `<Actions>` (But recommends to place up to 5 elements).
 
@@ -144,7 +144,7 @@ A block to hold [interactive components](block-elements.md#interactive-component
 
 - `id` / `blockId` (optional): A string of unique identifier of block.
 
-## <a name="context" id="context"></a> [`<Context>`: Context Block](https://api.slack.com/reference/messaging/blocks#context)
+## <a name="user-content-context" id="context"></a> [`<Context>`: Context Block](https://api.slack.com/reference/messaging/blocks#context)
 
 Display message context. It allows mixed contents consisted of texts and `<Image>` components or `<img>` tags.
 
@@ -186,7 +186,7 @@ Text contents will merge in pertinent mrkdwn elements automatically, but they al
 
 - `id` / `blockId` (optional): A string of unique identifier of block.
 
-## <a name="input" id="input"></a> [`<Input>`: Input Block](https://api.slack.com/reference/messaging/blocks#input)
+## <a name="user-content-input" id="input"></a> [`<Input>`: Input Block](https://api.slack.com/reference/messaging/blocks#input)
 
 Display one of interactive components for input to collect information from users.
 
@@ -243,7 +243,7 @@ If you want to use `<Input>` as layout block, you have to place one of [availabl
 
 `<Input>` component for layout block is provided for user that want templating with Slack API style rather than HTML style.
 
-## <a name="video" id="video"></a> [`<Video>`: Video Block](https://api.slack.com/reference/messaging/blocks#video)
+## <a name="user-content-video" id="video"></a> [`<Video>`: Video Block](https://api.slack.com/reference/messaging/blocks#video)
 
 A block for embedding a video. The `<video>` intrinsic HTML element works as well.
 
@@ -282,7 +282,7 @@ A block for embedding a video. The `<video>` intrinsic HTML element works as wel
 - `providerIconUrl` (optional): An image URL for the video provider icon.
 - `titleUrl` (optional): HTTPS URL for the hyperlink of the title text. It must correspond to the non-embeddable URL for the video.
 
-## <a name="file" id="file"></a> [`<File>`: File Block](https://api.slack.com/reference/messaging/blocks#file) (Only for messaging)
+## <a name="user-content-file" id="file"></a> [`<File>`: File Block](https://api.slack.com/reference/messaging/blocks#file) (Only for messaging)
 
 Display a remote file that was added to Slack workspace. [Learn about adding remote files in the document of Slack API.](https://api.slack.com/messaging/files/remote) _This block is only for [`<Blocks>` container](block-containers.md#blocks)._
 
@@ -298,7 +298,7 @@ Display a remote file that was added to Slack workspace. [Learn about adding rem
 - `id` / `blockId` (optional): A string of unique identifier of block.
 - `source` (optional): Override `source` field. At the moment, you should not take care this because only the default value `remote` is available.
 
-## <a name="call" id="call"></a> `<Call>`: Call Block (Only for messaging)
+## <a name="user-content-call" id="call"></a> `<Call>`: Call Block (Only for messaging)
 
 Display a card of the call that was registered to Slack workspace. [Learn about using the Calls API in the document of Slack API.](https://api.slack.com/apis/calls) _This block is only for [`<Blocks>` container](block-containers.md#blocks)._
 


### PR DESCRIPTION
Now GitHub is postprocessing Markdown anchor links to add prefix `user-content-` to each anchor. The documentation of jsx-slack is depending on the stable anchors defined by `<a name="xxx" id="xxx"></a>` and every links for external page have been broken. (Anchor links to the same page are still working)

So I've added `user-content-` prefix to all of anchor links that are referring to external pages in the jsx-slack reference.

In addition, every anchor definitions were updated to use the prefixed anchor in an obsoleted attribute `name`. The `id` attribute is keeping original anchor name. By making targetable with both anchors, we can make easy to move current documentation into the new site without broken links.