### PR TITLE
Add `<Input>` type variants `url`, `email`, and `number`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - [`<DateTimePicker>` interactive component](https://github.com/yhatt/jsx-slack/blob/main/docs/block-elements.md#user-content-date-time-picker) ([#276](https://github.com/yhatt/jsx-slack/issues/276), [#278](https://github.com/yhatt/jsx-slack/pull/278))
+- New `type` variants for [`<Input>`](https://github.com/yhatt/jsx-slack/blob/main/docs/block-elements.md#user-content-input): `url`, `email`, and `number` ([#277](https://github.com/yhatt/jsx-slack/issues/277), [#279](https://github.com/yhatt/jsx-slack/pull/279))
 
 ## v5.1.0 - 2022-07-16
 

--- a/demo/js/schema.js
+++ b/demo/js/schema.js
@@ -205,13 +205,18 @@ const schema = {
       ...inputComponentAttrs,
       name: null,
       actionId: null,
-      type: ['text', 'hidden', 'submit'],
+      type: ['text', 'url', 'email', 'number', 'hidden', 'submit'],
       placeholder: null,
       value: null,
       maxLength: null,
       minLength: null,
       autoFocus: [],
       dispatchAction: ['onCharacterEntered', 'onEnterPressed'],
+
+      // <Input type="number" />
+      decimal: [],
+      min: null,
+      max: null,
     },
     children: [
       'Select',
@@ -230,13 +235,18 @@ const schema = {
     attrs: {
       ...inputIntrinsicAttrs,
       name: null,
-      type: ['text', 'hidden', 'submit'],
+      type: ['text', 'url', 'email', 'number', 'hidden', 'submit'],
       placeholder: null,
       value: null,
       maxLength: null,
       minLength: null,
       autofocus: [],
       dispatchAction: ['onCharacterEntered', 'onEnterPressed'],
+
+      // <input type="number" />
+      decimal: [],
+      min: null,
+      max: null,
     },
     children: [
       'Select',

--- a/docs/block-elements.md
+++ b/docs/block-elements.md
@@ -908,7 +908,7 @@ The list of input components is following:
 - [`<CheckboxGroup>`](#checkbox-group)
 - [`<RadioButtonGroup>`](#radio-button-group)
 
-### <a name="user-content-input" id="input"></a> [`<Input>`: Plain-text input element](https://api.slack.com/reference/block-kit/block-elements#input)
+### <a name="user-content-input" id="input"></a> [`<Input>`: Text input element](https://api.slack.com/reference/block-kit/block-elements#input)
 
 `<Input>` component is for placing a single-line input form within supported container. It can place as children of the container component directly.
 
@@ -916,14 +916,14 @@ It has an interface similar to `<input>` HTML element and `<input>` intrinsic HT
 
 ```jsx
 <Modal title="My App">
-  <Input label="Title" type="text" name="Title" maxLength={80} required />
+  <Input label="Title" type="text" name="title" maxLength={80} required />
   <Input label="URL" type="url" name="url" placeholder="https://..." />
   <Input label="Email" type="email" name="email" required />
   <Input label="Number" type="number" name="num" required min={1} max={100} />
 </Modal>
 ```
 
-[<img src="./preview-btn.svg" width="240" />](https://jsx-slack.netlify.app/#bkb:jsx:eJx9kMEKwjAMhu8-RcgDrPMmsg48eBA2D6IP0LngCm1Xawbb2zu3VQTFU_KT_B9_kpVtrQywZkMSywF23mO-AsgOzncMRlVkJJ5fcwQe_LjF1DOCU5beA6v6gtyNG4mbFCHQvdOBahDfqMupiKAumMiZWm_UlZrW1BQkNsz-sRUiSRL8xdlbpU0k0Sxm1iL-hTh2tqIQ3W5Rs31UH2arncT1dOFY03TKkonpbfkTviNlTQ==)
+[<img src="./preview-btn.svg" width="240" />](https://jsx-slack.netlify.app/#bkb:jsx:eJx9kMEKgzAMhu97itAHUHcbwwo77DDQHcb2AHWGKbS16yIo4ruvWguDjZ2Snz__R5K0aCshgRqSyFkxwMEYlm0A0pM2HYEUJUrOrrPPgAbjpgh7YqCFmntvKNHnqB9U83GXTGDx2TUWK4i_UbdLHkCdlYGztEaKO9atrNByVhOZ1z6OoyhivzhHJRoZSOiFZ63i3xLnTpVoQ1qvysed-girRvNxO80Xupq44xwujZe3ZW-e62eJ)
 
 #### <a name="user-content-input-props" id="input-props"></a> Props
 
@@ -937,7 +937,7 @@ It has an interface similar to `<input>` HTML element and `<input>` intrinsic HT
 - `dispatchAction` (optional): By setting `true`, the input element will dispatch [`block_actions` payload](https://api.slack.com/reference/interaction-payloads/block-actions) when used this. By defining interaction type(s) as space-separated string or array, [you can determine when `<Input>` will return the payload.](https://api.slack.com/reference/block-kit/composition-objects#dispatch_action_config)
   - `onEnterPressed`: Payload is dispatched when hitting Enter key while focusing to the input component.
   - `onCharacterEntered`: Payload is dispatched when changing input characters.
-- `value` (optional): An initial value for plain-text input. It should be a valid string for the input type.
+- `value` (optional): An initial value for the input. It should be a valid string for the input type.
 - `autoFocus` (optional): Set whether the element will be set the focus automatically within the modal/home container.
 
 #### <a name="user-content-input-text-props" id="input-text-props"></a> Props for `<Input type="text">`

--- a/docs/block-elements.md
+++ b/docs/block-elements.md
@@ -916,28 +916,40 @@ It has an interface similar to `<input>` HTML element and `<input>` intrinsic HT
 
 ```jsx
 <Modal title="My App">
-  <Input label="Title" name="title" maxLength={80} required />
+  <Input label="Title" type="text" name="Title" maxLength={80} required />
+  <Input label="URL" type="url" name="url" placeholder="https://..." />
+  <Input label="Email" type="email" name="email" required />
+  <Input label="Number" type="number" name="num" required min={1} max={100} />
 </Modal>
 ```
 
-[<img src="./preview-btn.svg" width="240" />](https://jsx-slack.netlify.app/#bkb:jsx:eJyz8c1PScxRKMksyUm1VfKtVHAsKFCy41JQsPHMKygtUchJTErNsVUKAckrKeQl5gJVlUA4uYkVPql56SUZtkoWBkoKRamFpZlFqSkK-nZcNvpgY-0AosweLg==)
+[<img src="./preview-btn.svg" width="240" />](https://jsx-slack.netlify.app/#bkb:jsx:eJx9kMEKwjAMhu8-RcgDrPMmsg48eBA2D6IP0LngCm1Xawbb2zu3VQTFU_KT_B9_kpVtrQywZkMSywF23mO-AsgOzncMRlVkJJ5fcwQe_LjF1DOCU5beA6v6gtyNG4mbFCHQvdOBahDfqMupiKAumMiZWm_UlZrW1BQkNsz-sRUiSRL8xdlbpU0k0Sxm1iL-hTh2tqIQ3W5Rs31UH2arncT1dOFY03TKkonpbfkTviNlTQ==)
 
 #### <a name="user-content-input-props" id="input-props"></a> Props
 
 - `label` (**required**): The label string for the element.
 - `id` / `blockId` (optional): A string of unique identifier for [`<Input>` layout block](layout-blocks.md#user-content-input).
 - `name` / `actionId` (optional): A string of unique identifier for the action.
-- `type` (optional): `text` by default.
+- `type` (optional): Choose the type of input element from `text`, `url`, `email`, and `number`. `text` by default.
 - `title`/ `hint` (optional): Specify a helpful text appears under the element.
 - `placeholder` (optional): Specify a text string appears within the content of input is empty. (150 characters maximum)
 - `required` (optional): A boolean prop to specify whether any value must be filled when user confirms modal.
 - `dispatchAction` (optional): By setting `true`, the input element will dispatch [`block_actions` payload](https://api.slack.com/reference/interaction-payloads/block-actions) when used this. By defining interaction type(s) as space-separated string or array, [you can determine when `<Input>` will return the payload.](https://api.slack.com/reference/block-kit/composition-objects#dispatch_action_config)
   - `onEnterPressed`: Payload is dispatched when hitting Enter key while focusing to the input component.
   - `onCharacterEntered`: Payload is dispatched when changing input characters.
-- `value` (optional): An initial value for plain-text input.
+- `value` (optional): An initial value for plain-text input. It should be a valid string for the input type.
+- `autoFocus` (optional): Set whether the element will be set the focus automatically within the modal/home container.
+
+#### <a name="user-content-input-text-props" id="input-text-props"></a> Props for `<Input type="text">`
+
 - `maxLength` (optional): The maximum number of characters allowed for the input element. It must up to 3000 character.
 - `minLength` (optional): The minimum number of characters allowed for the input element.
-- `autoFocus` (optional): Set whether the element will be set the focus automatically within the modal/home container.
+
+#### <a name="user-content-input-number-props" id="input-number-props"></a> Props for `<Input type="number">`
+
+- `decimal` (optional): Set whether the number input element accepts decimal fractions. `false` by default (only accepts integer).
+- `max` (optional): The maximum value to accept for the number input.
+- `min` (optional): The minimum value to accept for the number input.
 
 ### <a name="user-content-input-hidden" id="input-hidden"></a> `<Input type="hidden">`: Store hidden values to the parent `<Modal>` and `<Home>`
 
@@ -1053,7 +1065,7 @@ The transformer takes an argument: JSON object of hidden values or `undefined` w
 
 #### Props
 
-It's exactly same as [`<Input>` component](#input-props), except `type` prop.
+It accepts exactly same props as for [`<Input type="text">` component](#input-props).
 
 ---
 

--- a/docs/jsx-components-for-block-kit.md
+++ b/docs/jsx-components-for-block-kit.md
@@ -52,7 +52,7 @@
 
 ### **[Input components](block-elements.md#user-content-input-components)**
 
-- [**`<Input>`**: Plain-text input element](block-elements.md#user-content-input)
+- [**`<Input>`**: Text input element](block-elements.md#user-content-input)
   - [**`<Input type="hidden">`**: Store hidden values to `<Modal>` and `<Home>`](block-elements.md#user-content-input-hidden)
   - [**`<Input type="submit">`**: Set submit button text of modal](block-elements.md#user-content-input-submit)
 - [**`<Textarea>`**: Plain-text input element with multiline](block-elements.md#user-content-textarea)

--- a/src/block-kit/composition/utils.ts
+++ b/src/block-kit/composition/utils.ts
@@ -54,7 +54,7 @@ export interface DispatchActionConfigComposition {
 
 export interface InputDispatchActionProps {
   /**
-   * @doc-plain-text-input
+   * @doc-input-dispatch-action
    * If defined interaction type(s) as space-separated string or array, you can
    * determine when the plain-text input component will return the payload, as
    * same as

--- a/src/block-kit/composition/utils.ts
+++ b/src/block-kit/composition/utils.ts
@@ -56,8 +56,7 @@ export interface InputDispatchActionProps {
   /**
    * @doc-input-dispatch-action
    * If defined interaction type(s) as space-separated string or array, you can
-   * determine when the plain-text input component will return the payload, as
-   * same as
+   * determine when the text input component will return the payload, as same as
    * [defining `dispatch_action_config` in Slack API](https://api.slack.com/reference/block-kit/composition-objects#dispatch_action_config).
    *
    * - `onEnterPressed`: Payload is dispatched when hitting Enter key while

--- a/src/block-kit/elements/EmailTextInput.ts
+++ b/src/block-kit/elements/EmailTextInput.ts
@@ -1,0 +1,41 @@
+import {
+  PlainTextInput as SlackPlainTextInput,
+  DispatchActionConfig,
+} from '@slack/types'
+import { createComponent } from '../../jsx-internals'
+import { plainText } from '../composition/utils'
+
+// TODO: Use official type when it was available in `@slack/types`
+interface SlackEmailTextInput
+  extends Omit<
+    SlackPlainTextInput,
+    'max_length' | 'min_length' | 'multiline' | 'type'
+  > {
+  type: 'email_text_input'
+}
+
+export interface EmailTextInputProps {
+  children?: never
+  actionId?: string
+  initialValue?: string
+  placeholder?: string
+  dispatchActionConfig?: DispatchActionConfig
+  focusOnLoad?: boolean
+}
+
+// NOTE: <EmailTextInput> is not public component
+export const EmailTextInput = createComponent<
+  EmailTextInputProps,
+  SlackEmailTextInput
+>('EmailTextInput', (props) => ({
+  type: 'email_text_input',
+  action_id: props.actionId,
+  placeholder:
+    // Placeholder for input HTML element should disable emoji conversion
+    props.placeholder
+      ? plainText(props.placeholder, { emoji: false })
+      : undefined,
+  initial_value: props.initialValue,
+  dispatch_action_config: props.dispatchActionConfig,
+  focus_on_load: props.focusOnLoad,
+}))

--- a/src/block-kit/elements/NumberTextInput.ts
+++ b/src/block-kit/elements/NumberTextInput.ts
@@ -1,0 +1,50 @@
+import {
+  PlainTextInput as SlackPlainTextInput,
+  DispatchActionConfig,
+} from '@slack/types'
+import { createComponent } from '../../jsx-internals'
+import { plainText } from '../composition/utils'
+
+// TODO: Use official type when it was available in `@slack/types`
+interface SlackNumberTextInput
+  extends Omit<
+    SlackPlainTextInput,
+    'max_length' | 'min_length' | 'multiline' | 'type'
+  > {
+  type: 'number_input'
+  is_decimal_allowed: boolean
+  max_value?: string
+  min_value?: string
+}
+
+export interface NumberTextInputProps {
+  children?: never
+  actionId?: string
+  initialValue?: string
+  placeholder?: string
+  isDecimalAllowed?: boolean
+  maxValue?: string
+  minValue?: string
+  dispatchActionConfig?: DispatchActionConfig
+  focusOnLoad?: boolean
+}
+
+// NOTE: <NumberTextInput> is not public component
+export const NumberTextInput = createComponent<
+  NumberTextInputProps,
+  SlackNumberTextInput
+>('NumberTextInput', (props) => ({
+  type: 'number_input',
+  action_id: props.actionId,
+  placeholder:
+    // Placeholder for input HTML element should disable emoji conversion
+    props.placeholder
+      ? plainText(props.placeholder, { emoji: false })
+      : undefined,
+  is_decimal_allowed: props.isDecimalAllowed ?? false,
+  min_value: props.minValue,
+  max_value: props.maxValue,
+  initial_value: props.initialValue,
+  dispatch_action_config: props.dispatchActionConfig,
+  focus_on_load: props.focusOnLoad,
+}))

--- a/src/block-kit/elements/UrlTextInput.ts
+++ b/src/block-kit/elements/UrlTextInput.ts
@@ -1,0 +1,41 @@
+import {
+  PlainTextInput as SlackPlainTextInput,
+  DispatchActionConfig,
+} from '@slack/types'
+import { createComponent } from '../../jsx-internals'
+import { plainText } from '../composition/utils'
+
+// TODO: Use official type when it was available in `@slack/types`
+interface SlackUrlTextInput
+  extends Omit<
+    SlackPlainTextInput,
+    'max_length' | 'min_length' | 'multiline' | 'type'
+  > {
+  type: 'url_text_input'
+}
+
+export interface UrlTextInputProps {
+  children?: never
+  actionId?: string
+  initialValue?: string
+  placeholder?: string
+  dispatchActionConfig?: DispatchActionConfig
+  focusOnLoad?: boolean
+}
+
+// NOTE: <UrlTextInput> is not public component
+export const UrlTextInput = createComponent<
+  UrlTextInputProps,
+  SlackUrlTextInput
+>('UrlTextInput', (props) => ({
+  type: 'url_text_input',
+  action_id: props.actionId,
+  placeholder:
+    // Placeholder for input HTML element should disable emoji conversion
+    props.placeholder
+      ? plainText(props.placeholder, { emoji: false })
+      : undefined,
+  initial_value: props.initialValue,
+  dispatch_action_config: props.dispatchActionConfig,
+  focus_on_load: props.focusOnLoad,
+}))

--- a/src/block-kit/layout/Input.tsx
+++ b/src/block-kit/layout/Input.tsx
@@ -326,15 +326,17 @@ export const wrapInInput = <T extends object>(
  * ### Input component for single-text
  *
  * `<Input label="..." />` means the input component for single text element and
- * will render `input` layout block containing with single-line plain text
- * input.
+ * will render `input` layout block containing with single-line text input.
  *
  * It has an interface very similar to `<input>` HTML element, but an important
  * difference is to require defining `label` prop.
  *
  * ```jsx
  * <Modal title="My App">
- *  <Input label="Title" name="title" maxLength={80} required />
+ *  <Input label="Title" type="text" name="title" maxLength={80} required />
+ *  <Input label="URL" type="url" name="url" placeholder="https://..." />
+ *  <Input label="Email" type="email" name="email" required />
+ *  <Input label="Number" type="number" name="num" required min={1} max={100} />
  * </Modal>
  * ```
  *

--- a/src/block-kit/layout/Input.tsx
+++ b/src/block-kit/layout/Input.tsx
@@ -8,13 +8,16 @@ import {
   createElementInternal,
   BuiltInComponent,
 } from '../../jsx-internals'
-import { DistributedProps, coerceToInteger } from '../../utils'
+import { DistributedProps, coerceToString, coerceToInteger } from '../../utils'
 import {
   plainText,
   inputDispatchActionConfig,
   InputDispatchActionProps,
 } from '../composition/utils'
+import { EmailTextInput } from '../elements/EmailTextInput'
+import { NumberTextInput } from '../elements/NumberTextInput'
 import { PlainTextInput } from '../elements/PlainTextInput'
+import { UrlTextInput } from '../elements/UrlTextInput'
 import {
   ActionProps,
   AutoFocusibleProps,
@@ -57,7 +60,7 @@ interface InputComponentBaseProps extends Omit<InputLayoutProps, 'children'> {
   /**
    * A string of unique identifier for the implicit parent `input` layout block.
    *
-   * @remarks
+   * @input-component-remarks
    * _This is only working in input components enabled by defining `label` prop._
    */
   blockId?: string
@@ -67,7 +70,7 @@ interface InputComponentBaseProps extends Omit<InputLayoutProps, 'children'> {
    * [`block_actions` payload](https://api.slack.com/reference/interaction-payloads/block-actions)
    * when used this.
    *
-   * @remarks
+   * @input-component-remarks
    * _This is only working in input components enabled by defining `label` prop._
    */
   dispatchAction?: boolean
@@ -76,7 +79,7 @@ interface InputComponentBaseProps extends Omit<InputLayoutProps, 'children'> {
    * Set `label` prop for the implicit parent `input` layout block, to display
    * the label string.
    *
-   * @remarks
+   * @input-component-remarks
    * Please notice that this prop is **always required** in input components,
    * and _**never** in interactive elements for `<Section>` and `<Actions>`._
    */
@@ -85,7 +88,7 @@ interface InputComponentBaseProps extends Omit<InputLayoutProps, 'children'> {
   /**
    * Set a helpful text appears under the element.
    *
-   * @remarks
+   * @input-component-remarks
    * _This is only working in input components enabled by defining `label` prop._
    */
   hint?: string
@@ -93,7 +96,7 @@ interface InputComponentBaseProps extends Omit<InputLayoutProps, 'children'> {
   /**
    * Set whether any value must be filled when user confirms modal.
    *
-   * @remarks
+   * @input-component-remarks
    * _This is only working in input components enabled by defining `label` prop._
    *
    * HTML-compatible `required` prop means reversed `optional` field in Slack
@@ -103,30 +106,12 @@ interface InputComponentBaseProps extends Omit<InputLayoutProps, 'children'> {
   required?: boolean
 }
 
-export interface InputTextProps
+interface InputTextBaseProps
   extends Omit<InputComponentBaseProps, 'dispatchAction'>,
     ActionProps,
     AutoFocusibleProps,
     InputDispatchActionProps {
   children?: never
-
-  /**
-   * Select input type from `text`, `hidden`, and `submit`.
-   *
-   * The default type is `text`, for the input layout block with single-text
-   * element.
-   */
-  type?: 'text'
-
-  /**
-   * Set the maximum number of characters user can enter into the text element.
-   */
-  maxLength?: number
-
-  /**
-   * Set the minimum number of characters user can enter into the text element.
-   */
-  minLength?: number
 
   /**
    * The placeholder text shown in empty text field.
@@ -143,8 +128,65 @@ export interface InputTextProps
    * defined value would be filled to the element only when the view was opened.
    * [`views.update`](https://api.slack.com/methods/views.update) cannot
    * update the text changed by user even if changed this prop.
+   *
+   * @remark
+   * If `type` prop is `url`, `email`, or `number`, an initial value should be a
+   * valid string for the type.
    */
   value?: string
+}
+
+export interface InputTextProps extends InputTextBaseProps {
+  /**
+   * Select input type from `text`, `url`, `email`, `number`, `hidden`, and
+   * `submit`.
+   *
+   * The default type is `text`, for the input layout block with single-text
+   * element.
+   */
+  type?: 'text'
+
+  /**
+   * Set the maximum number of characters user can enter into the text element.
+   */
+  maxLength?: number
+
+  /**
+   * Set the minimum number of characters user can enter into the text element.
+   */
+  minLength?: number
+}
+
+export interface InputURLProps extends InputTextBaseProps {
+  type: 'url'
+}
+
+export interface InputEmailProps extends InputTextBaseProps {
+  type: 'email'
+}
+
+export interface InputNumberProps extends Omit<InputTextBaseProps, 'value'> {
+  type: 'number'
+  value?: number | string
+
+  /**
+   * @doc-input-number
+   * Set whether the number input element accepts decimal fractions. The default
+   * value is `false`.
+   */
+  decimal?: boolean
+
+  /**
+   * @doc-input-number
+   * The maximum value to accept for this number input.
+   */
+  max?: number | string
+
+  /**
+   * @doc-input-number
+   * The minimum value to accept for this number input.
+   */
+  min?: number | string
 }
 
 interface InputHiddenProps {
@@ -186,7 +228,13 @@ export type InputComponentProps<
 > = DistributedProps<P | (P & InputComponentBaseProps & T)>
 
 export type InputProps = DistributedProps<
-  InputLayoutProps | InputTextProps | InputHiddenProps | InputSubmitProps
+  | InputLayoutProps
+  | InputTextProps
+  | InputURLProps
+  | InputEmailProps
+  | InputNumberProps
+  | InputHiddenProps
+  | InputSubmitProps
 >
 
 export const knownInputs = [
@@ -195,16 +243,19 @@ export const knownInputs = [
   'conversations_select',
   'datepicker',
   'datetimepicker',
+  'email_text_input',
   'external_select',
   'multi_channels_select',
   'multi_conversations_select',
   'multi_external_select',
   'multi_static_select',
   'multi_users_select',
+  'number_input',
   'plain_text_input',
   'radio_buttons',
   'static_select',
   'timepicker',
+  'url_text_input',
   'users_select',
 ]
 
@@ -377,15 +428,52 @@ export const Input: BuiltInComponent<InputProps> = createComponent<
   return wrapInInput(
     props.children ||
       cleanMeta(
-        <PlainTextInput
-          actionId={props.actionId || props.name}
-          initialValue={props.value}
-          maxLength={coerceToInteger(props.maxLength)}
-          minLength={coerceToInteger(props.minLength)}
-          placeholder={props.placeholder}
-          dispatchActionConfig={inputDispatchActionConfig(props)}
-          focusOnLoad={focusOnLoadFromProps(props)}
-        />
+        (() => {
+          const baseProps = {
+            actionId: props.actionId || props.name,
+            placeholder: props.placeholder,
+            dispatchActionConfig: inputDispatchActionConfig(props),
+            focusOnLoad: focusOnLoadFromProps(props),
+          }
+
+          if (props.type === 'url') {
+            return (
+              <UrlTextInput
+                {...baseProps}
+                // Empty string seems not to be allowed as initial value
+                initialValue={coerceToString(props.value) || undefined}
+              />
+            )
+          } else if (props.type === 'email') {
+            return (
+              <EmailTextInput
+                {...baseProps}
+                initialValue={coerceToString(props.value) || undefined}
+              />
+            )
+          } else if (props.type === 'number') {
+            return (
+              <NumberTextInput
+                {...baseProps}
+                initialValue={coerceToString(props.value) || undefined}
+                isDecimalAllowed={
+                  props.decimal === undefined ? undefined : !!props.decimal
+                }
+                maxValue={coerceToString(props.max)}
+                minValue={coerceToString(props.min)}
+              />
+            )
+          } else {
+            return (
+              <PlainTextInput
+                {...baseProps}
+                initialValue={props.value}
+                maxLength={coerceToInteger(props.maxLength)}
+                minLength={coerceToInteger(props.minLength)}
+              />
+            )
+          }
+        })()
       ),
     {
       ...props,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -44,6 +44,17 @@ export const coerceToInteger = (
   return coerced
 }
 
+export const coerceToString: {
+  (value: string | number | bigint): string
+  (value: string | number | bigint | undefined): string | undefined
+} = (value: string | number | bigint | undefined): any => {
+  if (typeof value === 'string') return value
+  if (typeof value === 'number' || typeof value === 'bigint')
+    return value.toString()
+
+  return undefined
+}
+
 export const intToAlpha = (num: number): string => {
   const int = coerceToInteger(num)
   if (int === undefined) return num.toString()

--- a/test/block-kit/block-elements/input-components.tsx
+++ b/test/block-kit/block-elements/input-components.tsx
@@ -243,6 +243,7 @@ describe('Input components', () => {
         action_id: 'action',
         focus_on_load: true,
         initial_value: 'https://example.com/',
+        placeholder: { type: 'plain_text', text: 'Input URL...', emoji: false },
       },
     }
 
@@ -254,6 +255,7 @@ describe('Input components', () => {
               label="URL"
               type="url"
               actionId="action"
+              placeholder="Input URL..."
               autoFocus
               value="https://example.com/"
             />
@@ -283,6 +285,11 @@ describe('Input components', () => {
         action_id: 'action',
         focus_on_load: true,
         initial_value: 'test@example.com',
+        placeholder: {
+          type: 'plain_text',
+          text: 'Input Email...',
+          emoji: false,
+        },
       },
     }
 
@@ -294,6 +301,7 @@ describe('Input components', () => {
               label="Email"
               type="email"
               actionId="action"
+              placeholder="Input Email..."
               autoFocus
               value="test@example.com"
             />
@@ -321,6 +329,11 @@ describe('Input components', () => {
       element: {
         type: 'number_input',
         action_id: 'action',
+        placeholder: {
+          type: 'plain_text',
+          text: 'Input percentage...',
+          emoji: false,
+        },
         focus_on_load: true,
         initial_value: '0.5',
         is_decimal_allowed: true,
@@ -337,6 +350,7 @@ describe('Input components', () => {
               label="Number"
               type="number"
               actionId="action"
+              placeholder="Input percentage..."
               autoFocus
               value={0.5}
               decimal

--- a/test/block-kit/block-elements/input-components.tsx
+++ b/test/block-kit/block-elements/input-components.tsx
@@ -233,6 +233,132 @@ describe('Input components', () => {
     })
   })
 
+  describe('<Input type="url">', () => {
+    const expectedInput = {
+      type: 'input',
+      label: { type: 'plain_text', text: 'URL', emoji: true },
+      optional: true,
+      element: {
+        type: 'url_text_input',
+        action_id: 'action',
+        focus_on_load: true,
+        initial_value: 'https://example.com/',
+      },
+    }
+
+    it('outputs input block with url text input element', () =>
+      expect(
+        JSXSlack(
+          <Modal title="test">
+            <Input
+              label="URL"
+              type="url"
+              actionId="action"
+              autoFocus
+              value="https://example.com/"
+            />
+          </Modal>
+        ).blocks
+      ).toStrictEqual([expectedInput]))
+
+    it('does not include initial_value field if the value is empty', () => {
+      const { blocks } = JSXSlack(
+        <Modal title="test">
+          <input label="url" type="url" value="" />
+        </Modal>
+      )
+
+      expect(blocks[0].element.type).toBe('url_text_input')
+      expect(blocks[0].element).not.toHaveProperty('initial_value')
+    })
+  })
+
+  describe('<Input type="email">', () => {
+    const expectedInput = {
+      type: 'input',
+      label: { type: 'plain_text', text: 'Email', emoji: true },
+      optional: true,
+      element: {
+        type: 'email_text_input',
+        action_id: 'action',
+        focus_on_load: true,
+        initial_value: 'test@example.com',
+      },
+    }
+
+    it('outputs input block with email text input element', () =>
+      expect(
+        JSXSlack(
+          <Modal title="test">
+            <Input
+              label="Email"
+              type="email"
+              actionId="action"
+              autoFocus
+              value="test@example.com"
+            />
+          </Modal>
+        ).blocks
+      ).toStrictEqual([expectedInput]))
+
+    it('does not include initial_value field if the value is empty', () => {
+      const { blocks } = JSXSlack(
+        <Modal title="test">
+          <input label="Email" type="email" value="" />
+        </Modal>
+      )
+
+      expect(blocks[0].element.type).toBe('email_text_input')
+      expect(blocks[0].element).not.toHaveProperty('initial_value')
+    })
+  })
+
+  describe('<Input type="number">', () => {
+    const expectedInput = {
+      type: 'input',
+      label: { type: 'plain_text', text: 'Number', emoji: true },
+      optional: true,
+      element: {
+        type: 'number_input',
+        action_id: 'action',
+        focus_on_load: true,
+        initial_value: '0.5',
+        is_decimal_allowed: true,
+        min_value: '0',
+        max_value: '1',
+      },
+    }
+
+    it('outputs input block with number input element', () =>
+      expect(
+        JSXSlack(
+          <Modal title="test">
+            <Input
+              label="Number"
+              type="number"
+              actionId="action"
+              autoFocus
+              value={0.5}
+              decimal
+              min={0}
+              max={1}
+            />
+          </Modal>
+        ).blocks
+      ).toStrictEqual([expectedInput]))
+
+    it('does not include initial_value field if the value is empty', () => {
+      const { blocks } = JSXSlack(
+        <Modal title="test">
+          <input label="Number" type="number" value="" />
+        </Modal>
+      )
+
+      expect(blocks[0].element.type).toBe('number_input')
+      expect(blocks[0].element).not.toHaveProperty('initial_value')
+    })
+  })
+
   describe('<Input type="hidden">', () => {
     it('assigns private metadata of parent modal as JSON string', () => {
       const modal: View = JSXSlack(

--- a/test/block-kit/container-components.tsx
+++ b/test/block-kit/container-components.tsx
@@ -428,7 +428,7 @@ describe('Container components', () => {
       ).toBe('foo=bar&abc=def')
     })
 
-    it('ignores <Input type="modal">', () => {
+    it('ignores <Input type="submit">', () => {
       expect(
         <Home>
           <Input type="submit" value="test" />


### PR DESCRIPTION
Extend `type` prop variants for `<Input>` component, to support URL input, email input, and number input. Slack app can provide proper input elements for purpose.

```jsx
<Modal title="Input variants">
  <Input type="text" label="Text" />
  <Input type="url" label="URL" />
  <Input type="email" label="Email" />
  <Input type="number" label="Number" min={0} max={1000} />
</Modal>
```

![Input variants](https://user-images.githubusercontent.com/3993388/198844565-a2e5a3d9-dcf3-4d27-bf6a-8d0a410e92f3.png)

This interface is very similar to jsx-slack v0's [(outdated) dialog support](https://api.slack.com/dialogs).
https://github.com/yhatt/jsx-slack/blob/v0.11.0/docs/jsx-components-for-dialog.md#html5-types

Close #277.

### ToDo

- [x] Add `<Input>` type variants `url`, `email`, and `number`
- [x] Update schema for demo
- [x] Tests
- [x] Documentations