### PR TITLE
Preserve URLs in links

### DIFF
--- a/src/mrkdwn/escape.ts
+++ b/src/mrkdwn/escape.ts
@@ -51,6 +51,9 @@ export const escapeChars = (
 export const escapeEntity = (str: string) =>
   str.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
 
+export const escapeURL = (url: string) =>
+  escapeEntity(url).replace(/\|+/g, encodeURI)
+
 const replaceUnmatchedString = (
   str: string,
   capturedMatcher: RegExp,

--- a/src/mrkdwn/stringifier.ts
+++ b/src/mrkdwn/stringifier.ts
@@ -3,7 +3,7 @@ import { phrasing as isPhrasing } from 'mdast-util-phrasing'
 import { parents } from 'unist-util-parents'
 import { JSXSlack } from '../jsx'
 import { detectSpecialLink, intToAlpha, intToRoman } from '../utils'
-import { escapeEntity, decodeEntity } from './escape'
+import { escapeEntity, escapeURL, decodeEntity } from './escape'
 import { makeIndent, measureWidth } from './measure'
 
 type Node = { type: string; [key: string]: any }
@@ -91,7 +91,7 @@ export class MrkdwnCompiler {
           // General URI
           return node.url === decodeEntity(content) && !content.includes('|')
             ? `<${content}>`
-            : `<${encodeURI(node.url)}|${content}>`
+            : `<${escapeURL(node.url)}|${content}>`
         }
       }
     },

--- a/test/mrkdwn.tsx
+++ b/test/mrkdwn.tsx
@@ -1064,10 +1064,15 @@ describe('HTML parser for mrkdwn', () => {
         '<https://example.com/|text>\n\n<https://example.com/|paragraph>\n\n&gt; <https://example.com/|blockquote>\n&gt; '
       ))
 
-    it('escapes chars in URL by percent encoding', () =>
+    it('does not escape most special characters in href URLs', () =>
       expect(
-        mrkdwn(<a href='https://example.com/?regex="<(i|em)>"'>escape test</a>)
-      ).toBe('<https://example.com/?regex=%22%3C(i%7Cem)%3E%22|escape test>'))
+        mrkdwn(<a href="https://example.com/?a?x=y%3Az">escape test</a>)
+      ).toBe('<https://example.com/?a?x=y%3Az|escape test>'))
+
+    it('escapes Slack-reserved special characters in href URLs', () =>
+      expect(mrkdwn(<a href="https://example.com/<>&|">escape test</a>)).toBe(
+        '<https://example.com/&lt;&gt;&amp;%7C|escape test>'
+      ))
 
     it('uses short syntax if the content and URL are exactly same', () => {
       expect(


### PR DESCRIPTION
In https://github.com/yhatt/jsx-slack/issues/288, @mrcljx pointed out that characters in link URLs that are already escaped get escaped again. For example:

```
<a href="https://google.com/a?x=y%3Az">show</a>
```

is encoded as

```
<https://google.com/a?x=y%253Az|show>
```

This PR removes implicit encoding from link URLs. Following @yhatt's [recommendation](https://github.com/yhatt/jsx-slack/issues/288#issuecomment-1418126341), it ensures we continue to escape characters that Slack reserves. `&`, `<`, and `>` are replaced by corresponding HTML entities, and we continue to use `urlEncode` to escape `|`.

closes https://github.com/yhatt/jsx-slack/issues/288