### PR TITLE
Support types field of conditional exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,14 +30,17 @@
   "module": "./module/src/index.mjs",
   "exports": {
     ".": {
+      "types": "./types/index.d.ts",
       "import": "./module/src/index.mjs",
       "default": "./lib/index.js"
     },
     "./jsx-dev-runtime": {
+      "types": "./jsx-dev-runtime.d.ts",
       "import": "./module/src/jsx-dev-runtime.mjs",
       "default": "./jsx-dev-runtime.js"
     },
     "./jsx-runtime": {
+      "types": "./jsx-runtime.d.ts",
       "import": "./module/src/jsx-runtime.mjs",
       "default": "./jsx-runtime.js"
     }


### PR DESCRIPTION
Thank you great library!

`--moduleResolution node16` or `--moduleResolution nodenext` with `tsc` will resolve the `types` field of the `exports` field of the npm package.

> "types" - can be used by typing systems to resolve the typing file for the given export. This condition should always be included first.
> https://nodejs.org/api/packages.html#community-conditions-definitions

If the `types` field is not specified, `import "jsx-slack"` will result in a type error.

reproduced repository
https://github.com/odan-sandbox/jsx-slack-node-esm-sandbox