### PR TITLE
Remove deprecated types

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -11,10 +11,3 @@ export type Node = JSXSlack.ChildElements
 export type FunctionComponent<P extends {} = {}> = JSXSlack.FunctionComponent<P>
 export type FC<P extends {} = {}> = JSXSlack.FC<P>
 export type PropsWithChildren<P extends {} = {}> = JSXSlack.PropsWithChildren<P>
-
-/** @deprecated Use FunctionComponent instead. */
-export type VoidFunctionComponent<P extends {} = {}> =
-  JSXSlack.VoidFunctionComponent<P>
-
-/** @deprecated Use FunctionComponent instead. */
-export type VFC<P extends {} = {}> = JSXSlack.VFC<P>

--- a/src/jsx.ts
+++ b/src/jsx.ts
@@ -72,18 +72,6 @@ export namespace JSXSlack {
   ) => Node<P> | null
   export type FC<P extends {} = {}> = FunctionComponent<P>
 
-  // Legacy aliases for FC
-  /** @deprecated Use an original type instead. */
-  export type Props<P extends {} = {}> = P
-  /** @deprecated Use FunctionComponent instead. */
-  export type FunctionalComponent<P extends {} = {}> = FunctionComponent<P>
-  /** @deprecated Use FunctionComponent instead. */
-  export type VoidFunctionComponent<P extends {} = {}> = FunctionComponent<P>
-  /** @deprecated Use FunctionComponent instead. */
-  export type VFC<P extends {} = {}> = FunctionComponent<P>
-  /** @deprecated Use FunctionComponent instead. */
-  export type VoidFunctionalComponent<P extends {} = {}> = FunctionComponent<P>
-
   export interface Node<P extends {} = {}> {
     /**
      * @internal


### PR DESCRIPTION
Removed following deprecated types:

- `VoidFunctionComponent`
- `VFC`
- `FunctionalComponent`
- `VoidFunctionalComponent`
-  `Props`