### PR TITLE
Don’t output `modules/node_modules` to npm

### DIFF
--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -51,6 +51,11 @@ export default [
       format: 'es',
       compact: true,
       preserveModules: true, // to emit tree-shakable scripts
+      // https://github.com/rollup/rollup/issues/3684#issuecomment-1535836196
+      entryFileNames: (chunkInfo) =>
+        chunkInfo.name.includes('node_modules')
+          ? `${chunkInfo.name.replace('node_modules', 'vendor')}.js`
+          : '[name].js',
     },
   },
 ]


### PR DESCRIPTION
The output included a `node_modules` folder inside `module/`, which was uploaded to npm[^1]

<details>
<summary>Screenshot of files on npm</summary>

![npm screenshot](https://github.com/yhatt/jsx-slack/assets/10807310/89d161a0-32ec-4feb-b672-7a573625775b)

</details>

This was causing problems with bun, see oven-sh/bun#7640. While ultimately Bun should fix this behaviour, it's still unusual to include `node_modules` on npm, so this changes the rollup config to prevent it.

You can see the related rollup issue here: rollup/rollup#3684 and the workaround in this comment[^2]

---

Diff of `yarn build; find ./module` before and after this change:

```diff
2,21d1
< ./module/node_modules
< ./module/node_modules/htm
< ./module/node_modules/htm/mini
< ./module/node_modules/htm/mini/index.mjs
< ./module/node_modules/unist-util-visit-parents
< ./module/node_modules/unist-util-visit-parents/lib
< ./module/node_modules/unist-util-visit-parents/lib/color.mjs
< ./module/node_modules/unist-util-visit-parents/lib/index.mjs
< ./module/node_modules/unist-util-is
< ./module/node_modules/unist-util-is/lib
< ./module/node_modules/unist-util-is/lib/index.mjs
< ./module/node_modules/mdast-util-phrasing
< ./module/node_modules/mdast-util-phrasing/lib
< ./module/node_modules/mdast-util-phrasing/lib/index.mjs
< ./module/node_modules/unist-util-visit
< ./module/node_modules/unist-util-visit/lib
< ./module/node_modules/unist-util-visit/lib/index.mjs
< ./module/node_modules/unist-util-parents
< ./module/node_modules/unist-util-parents/lib
< ./module/node_modules/unist-util-parents/lib/index.mjs
22a3,12
> ./module/vendor/htm
> ./module/vendor/htm/mini
> ./module/vendor/htm/mini/index.mjs
> ./module/vendor/unist-util-visit-parents
> ./module/vendor/unist-util-visit-parents/lib
> ./module/vendor/unist-util-visit-parents/lib/color.mjs
> ./module/vendor/unist-util-visit-parents/lib/index.mjs
> ./module/vendor/unist-util-is
> ./module/vendor/unist-util-is/lib
> ./module/vendor/unist-util-is/lib/index.mjs
23a14,22
> ./module/vendor/mdast-util-phrasing
> ./module/vendor/mdast-util-phrasing/lib
> ./module/vendor/mdast-util-phrasing/lib/index.mjs
> ./module/vendor/unist-util-visit
> ./module/vendor/unist-util-visit/lib
> ./module/vendor/unist-util-visit/lib/index.mjs
> ./module/vendor/unist-util-parents
> ./module/vendor/unist-util-parents/lib
> ./module/vendor/unist-util-parents/lib/index.mjs
```

<details>
<summary>Before</summary>

```sh
$ git switch main
$ yarn build
$ find ./module
./module
./module/node_modules
./module/node_modules/htm
./module/node_modules/htm/mini
./module/node_modules/htm/mini/index.mjs
./module/node_modules/unist-util-visit-parents
./module/node_modules/unist-util-visit-parents/lib
./module/node_modules/unist-util-visit-parents/lib/color.mjs
./module/node_modules/unist-util-visit-parents/lib/index.mjs
./module/node_modules/unist-util-is
./module/node_modules/unist-util-is/lib
./module/node_modules/unist-util-is/lib/index.mjs
./module/node_modules/mdast-util-phrasing
./module/node_modules/mdast-util-phrasing/lib
./module/node_modules/mdast-util-phrasing/lib/index.mjs
./module/node_modules/unist-util-visit
./module/node_modules/unist-util-visit/lib
./module/node_modules/unist-util-visit/lib/index.mjs
./module/node_modules/unist-util-parents
./module/node_modules/unist-util-parents/lib
./module/node_modules/unist-util-parents/lib/index.mjs
./module/vendor
./module/vendor/hastUtilToMdast.ts.mjs
./module/vendor/he.ts.mjs
./module/src
./module/src/date.mjs
./module/src/components.mjs
./module/src/error.mjs
./module/src/jsx.mjs
./module/src/jsx-runtime.mjs
./module/src/mrkdwn
./module/src/mrkdwn/jsx.mjs
./module/src/mrkdwn/measure.mjs
./module/src/mrkdwn/escape.mjs
./module/src/mrkdwn/parser.mjs
./module/src/mrkdwn/index.mjs
./module/src/mrkdwn/stringifier.mjs
./module/src/utils.mjs
./module/src/block-kit
./module/src/block-kit/input
./module/src/block-kit/input/Textarea.mjs
./module/src/block-kit/layout
./module/src/block-kit/layout/Header.mjs
./module/src/block-kit/layout/Context.mjs
./module/src/block-kit/layout/Call.mjs
./module/src/block-kit/layout/Video.mjs
./module/src/block-kit/layout/Input.mjs
./module/src/block-kit/layout/utils.mjs
./module/src/block-kit/layout/Image.mjs
./module/src/block-kit/layout/Actions.mjs
./module/src/block-kit/layout/File.mjs
./module/src/block-kit/layout/Divider.mjs
./module/src/block-kit/layout/Section.mjs
./module/src/block-kit/utils.mjs
./module/src/block-kit/other
./module/src/block-kit/other/SelectFragment.mjs
./module/src/block-kit/composition
./module/src/block-kit/composition/Confirm.mjs
./module/src/block-kit/composition/RadioButton.mjs
./module/src/block-kit/composition/Checkbox.mjs
./module/src/block-kit/composition/Mrkdwn.mjs
./module/src/block-kit/composition/utils.mjs
./module/src/block-kit/composition/Option.mjs
./module/src/block-kit/composition/Optgroup.mjs
./module/src/block-kit/container
./module/src/block-kit/container/utils.mjs
./module/src/block-kit/container/Modal.mjs
./module/src/block-kit/container/Blocks.mjs
./module/src/block-kit/container/Home.mjs
./module/src/block-kit/elements
./module/src/block-kit/elements/NumberTextInput.mjs
./module/src/block-kit/elements/CheckboxGroup.mjs
./module/src/block-kit/elements/RadioButtonGroup.mjs
./module/src/block-kit/elements/WorkflowButton.mjs
./module/src/block-kit/elements/UrlTextInput.mjs
./module/src/block-kit/elements/PlainTextInput.mjs
./module/src/block-kit/elements/Select.mjs
./module/src/block-kit/elements/utils.mjs
./module/src/block-kit/elements/Button.mjs
./module/src/block-kit/elements/UsersSelect.mjs
./module/src/block-kit/elements/Overflow.mjs
./module/src/block-kit/elements/EmailTextInput.mjs
./module/src/block-kit/elements/DatePicker.mjs
./module/src/block-kit/elements/ExternalSelect.mjs
./module/src/block-kit/elements/TimePicker.mjs
./module/src/block-kit/elements/DateTimePicker.mjs
./module/src/block-kit/elements/ConversationsSelect.mjs
./module/src/block-kit/elements/ChannelsSelect.mjs
./module/src/index.mjs
./module/src/jsx-dev-runtime.mjs
./module/src/tag.mjs
./module/src/data
./module/src/data/font-width.json.mjs
./module/src/jsx-internals.mjs
```

</details>

<details>
<summary>After</summary>

```sh
$ git switch ng/fix-rollup-esm-output
$ yarn build
$ find ./module
./module
./module/vendor
./module/vendor/htm
./module/vendor/htm/mini
./module/vendor/htm/mini/index.mjs
./module/vendor/unist-util-visit-parents
./module/vendor/unist-util-visit-parents/lib
./module/vendor/unist-util-visit-parents/lib/color.mjs
./module/vendor/unist-util-visit-parents/lib/index.mjs
./module/vendor/unist-util-is
./module/vendor/unist-util-is/lib
./module/vendor/unist-util-is/lib/index.mjs
./module/vendor/hastUtilToMdast.ts.mjs
./module/vendor/mdast-util-phrasing
./module/vendor/mdast-util-phrasing/lib
./module/vendor/mdast-util-phrasing/lib/index.mjs
./module/vendor/unist-util-visit
./module/vendor/unist-util-visit/lib
./module/vendor/unist-util-visit/lib/index.mjs
./module/vendor/unist-util-parents
./module/vendor/unist-util-parents/lib
./module/vendor/unist-util-parents/lib/index.mjs
./module/vendor/he.ts.mjs
./module/src
./module/src/date.mjs
./module/src/components.mjs
./module/src/error.mjs
./module/src/jsx.mjs
./module/src/jsx-runtime.mjs
./module/src/mrkdwn
./module/src/mrkdwn/jsx.mjs
./module/src/mrkdwn/measure.mjs
./module/src/mrkdwn/escape.mjs
./module/src/mrkdwn/parser.mjs
./module/src/mrkdwn/index.mjs
./module/src/mrkdwn/stringifier.mjs
./module/src/utils.mjs
./module/src/block-kit
./module/src/block-kit/input
./module/src/block-kit/input/Textarea.mjs
./module/src/block-kit/layout
./module/src/block-kit/layout/Header.mjs
./module/src/block-kit/layout/Context.mjs
./module/src/block-kit/layout/Call.mjs
./module/src/block-kit/layout/Video.mjs
./module/src/block-kit/layout/Input.mjs
./module/src/block-kit/layout/utils.mjs
./module/src/block-kit/layout/Image.mjs
./module/src/block-kit/layout/Actions.mjs
./module/src/block-kit/layout/File.mjs
./module/src/block-kit/layout/Divider.mjs
./module/src/block-kit/layout/Section.mjs
./module/src/block-kit/utils.mjs
./module/src/block-kit/other
./module/src/block-kit/other/SelectFragment.mjs
./module/src/block-kit/composition
./module/src/block-kit/composition/Confirm.mjs
./module/src/block-kit/composition/RadioButton.mjs
./module/src/block-kit/composition/Checkbox.mjs
./module/src/block-kit/composition/Mrkdwn.mjs
./module/src/block-kit/composition/utils.mjs
./module/src/block-kit/composition/Option.mjs
./module/src/block-kit/composition/Optgroup.mjs
./module/src/block-kit/container
./module/src/block-kit/container/utils.mjs
./module/src/block-kit/container/Modal.mjs
./module/src/block-kit/container/Blocks.mjs
./module/src/block-kit/container/Home.mjs
./module/src/block-kit/elements
./module/src/block-kit/elements/NumberTextInput.mjs
./module/src/block-kit/elements/CheckboxGroup.mjs
./module/src/block-kit/elements/RadioButtonGroup.mjs
./module/src/block-kit/elements/WorkflowButton.mjs
./module/src/block-kit/elements/UrlTextInput.mjs
./module/src/block-kit/elements/PlainTextInput.mjs
./module/src/block-kit/elements/Select.mjs
./module/src/block-kit/elements/utils.mjs
./module/src/block-kit/elements/Button.mjs
./module/src/block-kit/elements/UsersSelect.mjs
./module/src/block-kit/elements/Overflow.mjs
./module/src/block-kit/elements/EmailTextInput.mjs
./module/src/block-kit/elements/DatePicker.mjs
./module/src/block-kit/elements/ExternalSelect.mjs
./module/src/block-kit/elements/TimePicker.mjs
./module/src/block-kit/elements/DateTimePicker.mjs
./module/src/block-kit/elements/ConversationsSelect.mjs
./module/src/block-kit/elements/ChannelsSelect.mjs
./module/src/index.mjs
./module/src/jsx-dev-runtime.mjs
./module/src/tag.mjs
./module/src/data
./module/src/data/font-width.json.mjs
./module/src/jsx-internals.mjs
```

</details>

[^1]: https://www.npmjs.com/package/jsx-slack?activeTab=code
[^2]: https://github.com/rollup/rollup/issues/3684#issuecomment-1535836196