### PR TITLE
Fix rollup .mjs extension

### DIFF
--- a/docs/block-elements.md
+++ b/docs/block-elements.md
@@ -53,14 +53,14 @@ Similar to `<Button>`, but for running a [link trigger](https://api.slack.com/au
           customizable_input_parameters: [
             {
               name: 'input_parameter_a',
-              value: 'Value for input param A'
+              value: 'Value for input param A',
             },
             {
               name: 'input_parameter_b',
-              value: 'Value for input param B'
-            }
-          ]
-        }
+              value: 'Value for input param B',
+            },
+          ],
+        },
       }}
     >
       Run Workflow

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -54,8 +54,8 @@ export default [
       // https://github.com/rollup/rollup/issues/3684#issuecomment-1535836196
       entryFileNames: (chunkInfo) =>
         chunkInfo.name.includes('node_modules')
-          ? `${chunkInfo.name.replace('node_modules', 'vendor')}.js`
-          : '[name].js',
+          ? `${chunkInfo.name.replace('node_modules', 'vendor')}.mjs`
+          : '[name].mjs',
     },
   },
 ]


### PR DESCRIPTION
I had a typo in #308 and 6.1.0's[^1] ESM build is broken, sorry!

There was a `.js` extension instead of `.mjs`. I had amended the commit and forgot to push it to the PR, so the diff in the PR was from the correct version. This is the fix!

[^1]: https://github.com/yhatt/jsx-slack/releases/tag/v6.1.0