### PR TITLE
Update JSXSlackTemplateTag type: Accept readonly string array as template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- `JSXSlackTemplateTag` type now accepts pure readonly string array ([#312](https://github.com/yhatt/jsx-slack/pull/312))
+
 ## v6.1.1 - 2023-12-14
 
 ### Fixed

--- a/src/tag.ts
+++ b/src/tag.ts
@@ -4,7 +4,7 @@ import { createElementInternal } from './jsx-internals'
 import { he } from './prebundles/he'
 
 type JSXSlackTemplateTag = (
-  template: TemplateStringsArray,
+  template: readonly string[],
   ...substitutions: any[]
 ) => any
 
@@ -91,7 +91,7 @@ const render = htm.bind((type, props, ...children) =>
  */
 export const jsxslack: JSXSlackTemplateTag = (template, ...substitutions) =>
   render(
-    template,
+    template as TemplateStringsArray,
     ...substitutions.map((s) =>
       isString(s)
         ? Object.defineProperty(new String(s), strSubSymbol, { value: true })


### PR DESCRIPTION
TypeScript built-in `TemplateStringsArray` type (used by `htm`) requires having [`raw` propoerty](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/raw).

```typescript
interface TemplateStringsArray extends ReadonlyArray<string> {
    readonly raw: readonly string[];
}
```

`raw` is not supported by jsx-slack, so I updated `JSXSlackTemplateTag` type to accept just a readonly string array as template.

This change prevents type error in the (rare) case of directly use `jsxslack` as a function, just like `jsxslack([...], ...)`.

Related: #311