### PR TITLE
`<FileInput>` / `<Input type="file">` input component for the file input element

### DIFF
--- a/package.json
+++ b/package.json
@@ -110,6 +110,7 @@
     "jest-junit": "^16.0.0",
     "lodash.debounce": "^4.0.8",
     "mdast-util-phrasing": "^4.1.0",
+    "mime": "^4.0.1",
     "npm-run-all": "^4.1.5",
     "pako": "^2.1.0",
     "postcss": "^8.4.35",

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "test:coverage": "jest --coverage",
     "test:debug": "node --inspect ./node_modules/.bin/jest -i",
     "test:esm": "yarn build && node --experimental-vm-modules --no-warnings ./node_modules/.bin/jest -c jest.config.esm.mjs",
-    "types": "rimraf types && tsc --declaration --emitDeclarationOnly --outDir types",
+    "types": "rimraf types && tsc --project tsconfig.types.json --declaration --emitDeclarationOnly --outDir types",
     "version": "node ./tools/version.js && git add -A CHANGELOG.md"
   },
   "prettier": {

--- a/src/block-kit/container/Modal.tsx
+++ b/src/block-kit/container/Modal.tsx
@@ -184,6 +184,7 @@ const commonDefaultSubmit = plainText('Submit')
  * - `<DateTimePicker label="...">`
  * - `<CheckboxGroup label="...">`
  * - `<RadioButtonGroup label="...">`
+ * - `<FileInput label="...">`
  *
  * @example
  * ```jsx

--- a/src/block-kit/container/utils.ts
+++ b/src/block-kit/container/utils.ts
@@ -1,4 +1,4 @@
-import { ActionsBlock, Block, SectionBlock } from '@slack/types'
+import type { ActionsBlock, Block, SectionBlock } from '@slack/types'
 import { JSXSlackError } from '../../error'
 import { JSXSlack } from '../../jsx'
 import { createComponent } from '../../jsx-internals'

--- a/src/block-kit/elements/EmailTextInput.ts
+++ b/src/block-kit/elements/EmailTextInput.ts
@@ -1,18 +1,6 @@
-import {
-  PlainTextInput as SlackPlainTextInput,
-  DispatchActionConfig,
-} from '@slack/types'
+import type { EmailInput, DispatchActionConfig } from '@slack/types'
 import { createComponent } from '../../jsx-internals'
 import { plainText } from '../composition/utils'
-
-// TODO: Use official type when it was available in `@slack/types`
-interface SlackEmailTextInput
-  extends Omit<
-    SlackPlainTextInput,
-    'max_length' | 'min_length' | 'multiline' | 'type'
-  > {
-  type: 'email_text_input'
-}
 
 export interface EmailTextInputProps {
   children?: never
@@ -24,18 +12,18 @@ export interface EmailTextInputProps {
 }
 
 // NOTE: <EmailTextInput> is not public component
-export const EmailTextInput = createComponent<
-  EmailTextInputProps,
-  SlackEmailTextInput
->('EmailTextInput', (props) => ({
-  type: 'email_text_input',
-  action_id: props.actionId,
-  placeholder:
-    // Placeholder for input HTML element should disable emoji conversion
-    props.placeholder
-      ? plainText(props.placeholder, { emoji: false })
-      : undefined,
-  initial_value: props.initialValue,
-  dispatch_action_config: props.dispatchActionConfig,
-  focus_on_load: props.focusOnLoad,
-}))
+export const EmailTextInput = createComponent<EmailTextInputProps, EmailInput>(
+  'EmailTextInput',
+  (props) => ({
+    type: 'email_text_input',
+    action_id: props.actionId,
+    placeholder:
+      // Placeholder for input HTML element should disable emoji conversion
+      props.placeholder
+        ? plainText(props.placeholder, { emoji: false })
+        : undefined,
+    initial_value: props.initialValue,
+    dispatch_action_config: props.dispatchActionConfig,
+    focus_on_load: props.focusOnLoad,
+  }),
+)

--- a/src/block-kit/elements/FileInput.ts
+++ b/src/block-kit/elements/FileInput.ts
@@ -1,0 +1,67 @@
+import type { FileInput as SlackFileInput } from '@slack/types'
+import { JSXSlackError } from '../../error'
+import { createComponent } from '../../jsx-internals'
+import { coerceToInteger, coerceToString } from '../../utils'
+import type { FileInputProps as JSXSlackFileInputProps } from '../input/FileInput'
+
+export interface FileInputProps {
+  children?: never
+  actionId?: string
+  filetypes?: SlackFileInput['filetypes']
+  maxFiles?: SlackFileInput['max_files']
+}
+
+// NOTE: <FileInput> with Slack interface is not public component
+export const FileInput = createComponent<FileInputProps, SlackFileInput>(
+  'FileInput',
+  (props) => ({
+    type: 'file_input',
+    action_id: props.actionId,
+    filetypes: props.filetypes,
+    max_files: props.maxFiles,
+  }),
+)
+
+export const convertFileInputPropsToElementProps = (
+  props: Pick<JSXSlackFileInputProps, 'accept' | 'multiple'>,
+) => {
+  const { accept, multiple } = props
+
+  const filetypeSet = new Set(
+    ([] as string[]).concat(accept ?? []).flatMap((t) => {
+      const ts = coerceToString(t)
+      if (typeof ts !== 'string') return []
+
+      return ts.split(',').map((ext) => {
+        const trimmed = ext.trim()
+
+        if (trimmed.includes('/')) {
+          throw new JSXSlackError(
+            `The file input element accepts only file extensions, but got MIME type "${trimmed}" in "accept" prop.`,
+            props['__source'],
+          )
+        }
+
+        // Remove leading dot
+        if (trimmed.startsWith('.')) return trimmed.slice(1)
+
+        return trimmed
+      })
+    }),
+  )
+
+  const maxFiles = (() => {
+    if (multiple === true) return undefined // Rely on Slack's default
+    if (multiple === false) return 1
+
+    const multipleNumber = coerceToInteger(multiple)
+    if (typeof multipleNumber === 'number') return multipleNumber
+
+    return 1
+  })()
+
+  return {
+    filetypes: filetypeSet.size > 0 ? [...filetypeSet.values()] : undefined,
+    maxFiles,
+  } as const
+}

--- a/src/block-kit/elements/NumberTextInput.ts
+++ b/src/block-kit/elements/NumberTextInput.ts
@@ -1,21 +1,6 @@
-import {
-  PlainTextInput as SlackPlainTextInput,
-  DispatchActionConfig,
-} from '@slack/types'
+import type { NumberInput, DispatchActionConfig } from '@slack/types'
 import { createComponent } from '../../jsx-internals'
 import { plainText } from '../composition/utils'
-
-// TODO: Use official type when it was available in `@slack/types`
-interface SlackNumberTextInput
-  extends Omit<
-    SlackPlainTextInput,
-    'max_length' | 'min_length' | 'multiline' | 'type'
-  > {
-  type: 'number_input'
-  is_decimal_allowed: boolean
-  max_value?: string
-  min_value?: string
-}
 
 export interface NumberTextInputProps {
   children?: never
@@ -32,7 +17,7 @@ export interface NumberTextInputProps {
 // NOTE: <NumberTextInput> is not public component
 export const NumberTextInput = createComponent<
   NumberTextInputProps,
-  SlackNumberTextInput
+  NumberInput
 >('NumberTextInput', (props) => ({
   type: 'number_input',
   action_id: props.actionId,

--- a/src/block-kit/elements/UrlTextInput.ts
+++ b/src/block-kit/elements/UrlTextInput.ts
@@ -1,18 +1,6 @@
-import {
-  PlainTextInput as SlackPlainTextInput,
-  DispatchActionConfig,
-} from '@slack/types'
+import type { URLInput, DispatchActionConfig } from '@slack/types'
 import { createComponent } from '../../jsx-internals'
 import { plainText } from '../composition/utils'
-
-// TODO: Use official type when it was available in `@slack/types`
-interface SlackUrlTextInput
-  extends Omit<
-    SlackPlainTextInput,
-    'max_length' | 'min_length' | 'multiline' | 'type'
-  > {
-  type: 'url_text_input'
-}
 
 export interface UrlTextInputProps {
   children?: never
@@ -24,18 +12,18 @@ export interface UrlTextInputProps {
 }
 
 // NOTE: <UrlTextInput> is not public component
-export const UrlTextInput = createComponent<
-  UrlTextInputProps,
-  SlackUrlTextInput
->('UrlTextInput', (props) => ({
-  type: 'url_text_input',
-  action_id: props.actionId,
-  placeholder:
-    // Placeholder for input HTML element should disable emoji conversion
-    props.placeholder
-      ? plainText(props.placeholder, { emoji: false })
-      : undefined,
-  initial_value: props.initialValue,
-  dispatch_action_config: props.dispatchActionConfig,
-  focus_on_load: props.focusOnLoad,
-}))
+export const UrlTextInput = createComponent<UrlTextInputProps, URLInput>(
+  'UrlTextInput',
+  (props) => ({
+    type: 'url_text_input',
+    action_id: props.actionId,
+    placeholder:
+      // Placeholder for input HTML element should disable emoji conversion
+      props.placeholder
+        ? plainText(props.placeholder, { emoji: false })
+        : undefined,
+    initial_value: props.initialValue,
+    dispatch_action_config: props.dispatchActionConfig,
+    focus_on_load: props.focusOnLoad,
+  }),
+)

--- a/src/block-kit/index.ts
+++ b/src/block-kit/index.ts
@@ -32,6 +32,7 @@ export { WorkflowButton } from './elements/WorkflowButton'
 
 // Input components
 export { Textarea } from './input/Textarea'
+export { FileInput } from './input/FileInput'
 
 // Composition objects
 export { Checkbox } from './composition/Checkbox'

--- a/src/block-kit/input/FileInput.tsx
+++ b/src/block-kit/input/FileInput.tsx
@@ -1,0 +1,47 @@
+/** @jsx createElementInternal */
+import type { InputBlock, FileInput as SlackFileInput } from '@slack/types'
+import {
+  cleanMeta,
+  createComponent,
+  createElementInternal,
+} from '../../jsx-internals'
+import {
+  FileInput as FileInputElement,
+  convertFileInputPropsToElementProps,
+} from '../elements/FileInput'
+import { wrapInInput, type InputFileProps } from '../layout/Input'
+
+export interface FileInputProps extends Omit<InputFileProps, 'type'> {}
+
+/**
+ * The input component for rendering `input` layout block containing
+ * [a file input element](https://api.slack.com/reference/block-kit/block-elements#file_input)
+ *
+ * It should place on immidiate children of container component <Modal>.
+ *
+ * ```jsx
+ * <Modal title="My App">
+ *   <FileInput
+ *     label="Resume"
+ *     actionId="resume"
+ *     accept=".pdf,.doc,.docx"
+ *   />
+ * </Modal>
+ * ```
+ *
+ * @return The partial JSON for `input` layout block with a file input element
+ */
+export const FileInput = createComponent<FileInputProps, InputBlock>(
+  'FileInput',
+  (props): any =>
+    wrapInInput(
+      cleanMeta(
+        <FileInputElement
+          actionId={props.actionId || props.name}
+          {...convertFileInputPropsToElementProps(props)}
+        />,
+      ) as SlackFileInput,
+      props,
+      FileInput,
+    ),
+)

--- a/src/block-kit/layout/Input.tsx
+++ b/src/block-kit/layout/Input.tsx
@@ -15,6 +15,10 @@ import {
   InputDispatchActionProps,
 } from '../composition/utils'
 import { EmailTextInput } from '../elements/EmailTextInput'
+import {
+  FileInput,
+  convertFileInputPropsToElementProps,
+} from '../elements/FileInput'
 import { NumberTextInput } from '../elements/NumberTextInput'
 import { PlainTextInput } from '../elements/PlainTextInput'
 import { UrlTextInput } from '../elements/UrlTextInput'
@@ -138,8 +142,8 @@ interface InputTextBaseProps
 
 export interface InputTextProps extends InputTextBaseProps {
   /**
-   * Select input type from `text`, `url`, `email`, `number`, `hidden`, and
-   * `submit`.
+   * Select input type from `text`, `url`, `email`, `number`, `file`, `hidden`,
+   * and `submit`.
    *
    * The default type is `text`, for the input layout block with single-text
    * element.
@@ -189,6 +193,39 @@ export interface InputNumberProps extends Omit<InputTextBaseProps, 'value'> {
   min?: number | string
 }
 
+export interface InputFileProps
+  extends Omit<InputComponentBaseProps, 'dispatchAction'>,
+    ActionProps {
+  children?: never
+  type: 'file'
+
+  /**
+   * @doc-input-file
+   * Set comma-separated string(s) of file extensions that can be uploaded.
+   * Specified file types are validated and normalized by Slack API.
+   *
+   * The file types of actually uploaded files will not validate. Users may
+   * upload files by ignoring specified extensions.
+   *
+   * @remarks
+   * Setting MIME types are not supported because the Slack platform does not
+   * support all file types covered by MIME. Please use file extensions only.
+   */
+  accept?: string | string[]
+
+  /**
+   * @doc-input-file
+   * Set whether the file input element accepts multiple files.
+   *
+   * By setting `true`, the file input element will accept up to the maximum
+   * number of files allowed by the Slack API. (Currently 10 files)
+   *
+   * By setting 1-10 number, the file input element will accept up to the
+   * specified number of files.
+   */
+  multiple?: boolean | number
+}
+
 interface InputHiddenProps {
   children?: never
   type: 'hidden'
@@ -233,6 +270,7 @@ export type InputProps = DistributedProps<
   | InputURLProps
   | InputEmailProps
   | InputNumberProps
+  | InputFileProps
   | InputHiddenProps
   | InputSubmitProps
 >
@@ -245,6 +283,7 @@ export const knownInputs = [
   'datetimepicker',
   'email_text_input',
   'external_select',
+  'file_input',
   'multi_channels_select',
   'multi_conversations_select',
   'multi_external_select',
@@ -463,6 +502,13 @@ export const Input: BuiltInComponent<InputProps> = createComponent<
                 }
                 maxValue={coerceToString(props.max)}
                 minValue={coerceToString(props.min)}
+              />
+            )
+          } else if (props.type === 'file') {
+            return (
+              <FileInput
+                actionId={props.actionId || props.name}
+                {...convertFileInputPropsToElementProps(props)}
               />
             )
           } else {

--- a/tsconfig.types.json
+++ b/tsconfig.types.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": ["test"]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -4865,6 +4865,11 @@ mime@^2:
   resolved "https://registry.yarnpkg.com/mime/-/mime-2.6.0.tgz#a2a682a95cd4d0cb1d6257e28f83da7e35800367"
   integrity sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==
 
+mime@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/mime/-/mime-4.0.1.tgz#ad7563d1bfe30253ad97dedfae2b1009d01b9470"
+  integrity sha512-5lZ5tyrIfliMXzFtkYyekWbtRXObT9OWa8IwQ5uxTBDHucNNwniRqo0yInflj+iYi5CBa6qxadGzGarDfuEOxA==
+
 mimic-fn@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-2.1.0.tgz#7ed2c2ccccaf84d3ffcb7a69b57711fc2083401b"


### PR DESCRIPTION
The `<FileInput>` component provides the file input to `<Modal>`.

```jsx
<Modal title="Send resume">
  <FileInput
    label="Resume"
    actionId="resume"
    accept=".pdf,.doc,.docx"
    required
    hint="Attach your resume"
  />
</Modal>
```

For HTML compatibility, `<input type="file" />` is also working.  It provides a better interface for web developers.

```jsx
<Modal title="Post">
  <input label="Title" name="title" required maxLength={200} />
  <textarea label="Message" name="message" required maxLength={2000} />
  <input type="file" label="Attachments" name="attachments" multiple />
  <input type="submit" value="Send" />
</Modal>
```

Resolves #305.

> [!WARNING]
> Setting MIME types as `accept` prop are not supported because the Slack platform does not support all file types covered by MIME.

### ToDo

- [x] Implementation
  - [x] `<FileInput>`
  - [x] `<Input type="file">`
- [ ] Tests
- [ ] Docs
- [ ] REPL